### PR TITLE
feat: split projector quiz view and persist imports

### DIFF
--- a/ozge/.github/workflows/deploy.yml
+++ b/ozge/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy Özge Classroom
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GH_USERNAME: ${{ secrets.GH_USERNAME }}
+      GH_EMAIL: ${{ secrets.GH_EMAIL }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_REPO: ${{ secrets.GH_REPO }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare and push
+        run: |
+          bash scripts/prepare_and_push.sh
+
+  deploy-gh-pages:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      GH_USERNAME: ${{ secrets.GH_USERNAME }}
+      GH_EMAIL: ${{ secrets.GH_EMAIL }}
+      GIT_AUTHOR_NAME: ${{ secrets.GH_USERNAME }}
+      GIT_AUTHOR_EMAIL: ${{ secrets.GH_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config user.name "$GH_USERNAME"
+          git config user.email "$GH_EMAIL"
+      - name: Ensure gh-pages branch
+        run: |
+          git fetch origin gh-pages || true
+          git switch gh-pages || git switch -c gh-pages
+      - name: Push to gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git push origin gh-pages
+      - name: Publish summary
+        run: |
+          echo "### Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "Latest site: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> $GITHUB_STEP_SUMMARY

--- a/ozge/.gitignore
+++ b/ozge/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/ozge/README.md
+++ b/ozge/README.md
@@ -1,0 +1,106 @@
+# Özge – Classroom Edition
+
+Offline-first classroom toolkit featuring a teacher dashboard, projector view, behavior tracking, content management with OCR, analytics, and deployment automation.
+
+## Features
+
+- **Dual-screen workflow** – Launch a synced Projector View (via `window.open`) with BroadcastChannel and localStorage fallback.
+- **Mode hub** – Quiz, Puzzle, Speak, Story, Draw & Spell, Bonus Blitz, Calm Down overlay, and teacher-only tabs for content, analytics, logs, settings, and class admin.
+- **Split reveal quiz** – Projector view shows questions while answer choices stay private on the teacher dashboard for guided pacing.
+- **Behavior & discipline** – Group scoring, quick behavior buttons (good, warning, penalty), automatic Team Spirit bonus, calm overlay, attendance capture, and lesson log entries.
+- **Draw & Spell** – Touch-friendly canvas with undo/redo, palette, PNG export, per-class gallery, and approve-to-projector with PIN gate.
+- **Content Manager** – Import PDF/image files, crop images offline, perform heuristic OCR, auto-cluster into units, map units to modes, and manage portable unit packs.
+- **AI Lesson Helper** – Rule-based summaries, vocabulary definitions, MCQs with difficulty tags per unit.
+- **Speaking practice** – Web Speech API integration with offline scoring fallback, lesson log storage, manual bonus.
+- **Weekly analytics** – Accuracy, difficult words, behavior trends, export to JSON/CSV, and print-ready view.
+- **Automation** – `scripts/prepare_and_push.sh` prepares commits, pushes `main`, and publishes gh-pages; GitHub Actions workflow triggers on pushes, weekdays 05:00 Europe/Istanbul, or manual dispatch.
+
+## Getting Started
+
+1. Open `ozge/index.html` in a modern browser. The Teacher Dashboard runs fully offline.
+2. Launch the Projector View from the dashboard header to open `projector.html` in a new window.
+3. Switch among the four preset classes (5A–5D); each maintains isolated units, rosters, scores, logs, and snapshots.
+
+## Content Management
+
+- Drag-and-drop or select PDF/image files in the Content Manager tab.
+- For images, adjust crop sliders and run offline OCR to extract clean text.
+- Units auto-generate with summaries, vocabulary lists, and MCQs; map units to activity modes via chips.
+- Export/import portable unit packs (`.json`) scoped per class.
+- Imported files are saved to a local IndexedDB store per class. Review, download, or delete them from the **Stored Files** panel.
+
+## Offline Stored Files
+
+- Imported PDFs/images stay on the current device inside an IndexedDB database (no remote upload).
+- Each class keeps its own library; switching classes refreshes the stored list.
+- Download buttons rebuild the original file blob so you can archive or reimport later.
+- Delete actions prompt for confirmation and immediately remove the file from storage.
+
+## Desktop Packaging (EXE)
+
+Package the web app as a desktop executable using the bundled Electron configuration:
+
+```bash
+cd ozge
+./scripts/build_exe.sh win   # Windows 64-bit build
+./scripts/build_exe.sh linux # Linux 64-bit build
+```
+
+- Requires Node.js 18+ with npm available on the packaging machine.
+- The script installs dev dependencies on first run and caches them under `node_modules`.
+- Windows builds output to `ozge/dist/Ozge Classroom-win32-x64/` with `Ozge Classroom.exe` ready for offline distribution.
+- Linux builds emit an AppImage-style directory under `dist/`.
+- You can launch a desktop preview via `npm start` (after `npm install`) which wraps `index.html` inside an Electron shell.
+
+## Behavior & Moderation
+
+- Behavior controls adjust scores and add log entries (penalties require PIN, default `1234`).
+- Calm Down Mode activates during Emergency STOP, dimming screens and muting interactions.
+- All sensitive actions prompt for PIN; update the code under **Settings**.
+
+## Deployment Automation
+
+### Required Secrets
+
+Configure the following repository secrets so CI can publish automatically:
+
+| Secret | Purpose |
+| --- | --- |
+| `GH_USERNAME` | Git username used for CI commits |
+| `GH_EMAIL` | Email for CI commits |
+| `GH_TOKEN` | Personal access token with `repo` scope |
+| `GH_REPO` | Full HTTPS repository URL (e.g., `https://github.com/owner/ozge-classroom.git`) |
+
+### Local Push Script
+
+Run the helper script from the repository root:
+
+```bash
+GH_USERNAME="your-username" \
+GH_EMAIL="you@example.com" \
+GH_TOKEN="ghp_xxx" \
+GH_REPO="https://github.com/owner/ozge-classroom.git" \
+bash scripts/prepare_and_push.sh
+```
+
+The script commits all changes to `main`, pushes to the remote, then updates the `gh-pages` branch using the `ozge/` directory contents.
+
+### GitHub Actions
+
+Workflow file: `.github/workflows/deploy.yml`
+
+- Triggers on push to `main`, scheduled weekdays at 05:00 Europe/Istanbul (`0 2 * * 1-5` UTC), and manual `workflow_dispatch`.
+- `build` job checks out the repo and runs `scripts/prepare_and_push.sh` using repo secrets.
+- `deploy-gh-pages` job ensures the `gh-pages` branch exists, pushes it with `GH_TOKEN`, and posts the site URL summary.
+
+The published site lives at `https://<owner>.github.io/<repository>/` after gh-pages updates.
+
+## Adjusting the Schedule
+
+The cron line in the workflow can be edited to change timing. Remember Istanbul time is UTC+3 with no DST; adjust accordingly before converting to UTC.
+
+## Safety & Accessibility
+
+- Minimum touch target ≥56px, high-contrast gradient theme, ARIA labels, and keyboard shortcuts for drawing (N, C, S, [, ], E, P).
+- Offline heuristics avoid external network calls; OCR and AI helpers run locally.
+- No third-party CDNs or dynamic imports; all assets bundle inside `/ozge`.

--- a/ozge/assets/icons.svg
+++ b/ozge/assets/icons.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="logo" viewBox="0 0 120 120">
+    <defs>
+      <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+        <stop offset="0" stop-color="#3c50ff"/>
+        <stop offset="1" stop-color="#6ad5ff"/>
+      </linearGradient>
+    </defs>
+    <circle cx="60" cy="60" r="58" fill="url(#g)" opacity="0.85"/>
+    <path d="M36 84c10-22 24-32 44-32l-8-16-20 6-4-14 26-8 16 30c8 16 14 32 14 48H84c0-12-4-24-12-36-14 2-26 10-36 22z" fill="#fff"/>
+  </symbol>
+  <symbol id="hourglass" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M6 2h12v4c0 1.7-.6 3.2-1.7 4.3l-1.7 1.7 1.7 1.7C17.4 14.8 18 16.3 18 18v4H6v-4c0-1.7.6-3.2 1.7-4.3l1.7-1.7-1.7-1.7C6.6 9.2 6 7.7 6 6V2zm2 2v2c0 .8.3 1.5.9 2.1L11 10l-2.1 1.9c-.6.6-.9 1.3-.9 2.1v2h8v-2c0-.8-.3-1.5-.9-2.1L13 10l2.1-1.9c.6-.6.9-1.3.9-2.1V4H8z"/>
+  </symbol>
+</svg>

--- a/ozge/assets/sounds/soft-chime.txt
+++ b/ozge/assets/sounds/soft-chime.txt
@@ -1,0 +1,1 @@
+Base64 placeholder for soft chime audio can be replaced with a short <1s WAV.

--- a/ozge/css/styles.css
+++ b/ozge/css/styles.css
@@ -1,0 +1,745 @@
+:root {
+  color-scheme: light;
+  --bg: linear-gradient(180deg, #4f6df5, #ffffff 60%);
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-strong: rgba(255, 255, 255, 0.95);
+  --border: rgba(79, 109, 245, 0.18);
+  --shadow: 0 20px 50px rgba(79, 109, 245, 0.2);
+  --radius-xl: 28px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --primary: #3c50ff;
+  --primary-dark: #1a2adf;
+  --accent: #f58b4c;
+  --success: #4ad66d;
+  --warning: #ffba3b;
+  --danger: #ff5467;
+  --font: "Poppins", "Segoe UI", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font);
+  background: var(--bg);
+  color: #0f1a2a;
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.view {
+  display: none;
+}
+
+.view.view-active {
+  display: block;
+}
+
+#splash {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+}
+
+.splash-inner {
+  background: var(--surface);
+  padding: 3rem 4rem;
+  border-radius: var(--radius-xl);
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.splash-inner .logo {
+  width: 80px;
+  height: 80px;
+  fill: var(--primary);
+}
+
+button {
+  font-family: inherit;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  border: 2px solid transparent;
+  padding: 0.75rem 1.6rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background: var(--surface-strong);
+  color: #0f1a2a;
+}
+
+button:hover, button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(79, 109, 245, 0.15);
+}
+
+button:focus-visible {
+  outline: 3px solid var(--primary);
+  outline-offset: 2px;
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+button.ghost {
+  background: transparent;
+  border-color: rgba(15, 26, 42, 0.12);
+}
+
+button.danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+#main-header {
+  backdrop-filter: blur(18px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--surface-strong);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.brand svg {
+  width: 40px;
+  height: 40px;
+  fill: var(--primary);
+}
+
+.class-switcher {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.class-chip {
+  min-width: 64px;
+  background: rgba(60, 80, 255, 0.12);
+  border: none;
+}
+
+.class-chip.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 1.5rem 4rem;
+  gap: 1.5rem;
+}
+
+#teacher-tabs {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(120px, 1fr);
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+#teacher-tabs .tab {
+  background: rgba(255, 255, 255, 0.5);
+  border: none;
+}
+
+#teacher-tabs .tab.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+#view-container {
+  background: var(--surface);
+  border-radius: var(--radius-xl);
+  padding: 2rem;
+  box-shadow: var(--shadow);
+}
+
+.mode-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.home-card {
+  padding: 2rem 1.25rem;
+  font-size: 1.2rem;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-lg);
+}
+
+.scoreboard {
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+}
+
+.drop-zone {
+  margin-top: 1rem;
+  padding: 2rem;
+  border: 2px dashed rgba(79, 109, 245, 0.4);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  color: rgba(15, 26, 42, 0.7);
+}
+
+.drop-zone.dragging {
+  border-style: solid;
+  background: rgba(79, 109, 245, 0.08);
+}
+
+.groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.group-card {
+  background: var(--surface-strong);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid rgba(15, 26, 42, 0.1);
+}
+
+.group-card header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.group-card .avatar {
+  display: inline-flex;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  background: rgba(79, 109, 245, 0.15);
+}
+
+.group-card dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+dl dt {
+  font-weight: 600;
+}
+
+dl dd {
+  margin: 0;
+}
+
+.behavior-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.behavior-controls button {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 1.4rem;
+}
+
+.unit-card {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 8px 20px rgba(15, 26, 42, 0.06);
+}
+
+.unit-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.unit-card h4 {
+  margin: 0;
+}
+
+.word-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem;
+}
+
+.word-list li {
+  background: rgba(79, 109, 245, 0.08);
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--radius-md);
+  font-size: 0.95rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.mode-chip-row {
+  margin-bottom: 1rem;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 109, 245, 0.3);
+  background: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+}
+
+.chip.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.preview-card {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  box-shadow: 0 10px 24px rgba(15, 26, 42, 0.08);
+}
+
+.preview-card header {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.preview-card canvas {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(15, 26, 42, 0.1);
+}
+
+.crop-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.crop-controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  gap: 0.25rem;
+}
+
+.ocr-output {
+  background: rgba(15, 26, 42, 0.05);
+  padding: 0.75rem;
+  border-radius: var(--radius-md);
+  max-height: 160px;
+  overflow: auto;
+  font-size: 0.85rem;
+}
+
+.caption {
+  font-size: 0.85rem;
+  color: rgba(15, 26, 42, 0.6);
+  margin-top: 0.25rem;
+}
+
+.stored-files {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.stored-file {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  box-shadow: 0 12px 28px rgba(15, 26, 42, 0.08);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stored-file header h4 {
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.stored-file .meta {
+  font-size: 0.85rem;
+  color: rgba(15, 26, 42, 0.6);
+}
+
+.stored-file .preview {
+  font-size: 0.9rem;
+  color: rgba(15, 26, 42, 0.75);
+  line-height: 1.4;
+}
+
+.stored-file .actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+#pin-dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#pin-dialog[hidden] {
+  display: none;
+}
+
+#pin-dialog .dialog {
+  background: #fff;
+  padding: 2rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  width: min(360px, 90vw);
+}
+
+#pin-dialog input {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 1.4rem;
+  text-align: center;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(15, 26, 42, 0.25);
+}
+
+.dialog-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+/* Projector */
+body[data-role="projector"] {
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.92), #ddebff);
+}
+
+.projector-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 2rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-bottom: 2px solid rgba(15, 26, 42, 0.12);
+  backdrop-filter: blur(10px);
+}
+
+.projector-title {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.projector-title svg {
+  width: 56px;
+  height: 56px;
+  fill: var(--primary);
+}
+
+.projector-status {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 1.3rem;
+}
+
+.projector-section {
+  display: none;
+  padding: 2rem;
+}
+
+.projector-section.active {
+  display: block;
+}
+
+.projector-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.projector-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-xl);
+  padding: 2rem;
+  text-align: center;
+  box-shadow: var(--shadow);
+  min-height: 220px;
+}
+
+.projector-mode-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.projector-instruction {
+  font-size: 2rem;
+  text-align: center;
+  margin-top: 3rem;
+}
+
+.projector-quiz-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-xl);
+  padding: 2.5rem;
+  box-shadow: 0 24px 48px rgba(15, 26, 42, 0.12);
+  max-width: 960px;
+  margin: 2rem auto 0;
+  text-align: center;
+}
+
+.projector-quiz-card h3 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: var(--primary);
+}
+
+.projector-quiz-card p {
+  font-size: 2.2rem;
+  line-height: 1.4;
+  margin-bottom: 1.5rem;
+}
+
+.projector-quiz-note {
+  display: inline-block;
+  margin-top: 1rem;
+  font-size: 1rem;
+  color: rgba(15, 26, 42, 0.7);
+}
+
+.projector-await {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  min-height: 40vh;
+  color: #0f1a2a;
+}
+
+.projector-blackout-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+  color: #fff;
+  background: rgba(15, 26, 42, 0.9);
+  border-radius: var(--radius-xl);
+  padding: 3rem;
+}
+
+.projector-footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  background: rgba(0, 0, 0, 0.1);
+  color: #0f1a2a;
+}
+
+.projector-footer .avatars,
+.projector-footer .scores {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  font-size: 1.3rem;
+}
+
+.projector-banner {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.8rem 1.4rem;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow);
+  font-size: 1.2rem;
+}
+
+/* Canvas controls */
+.draw-toolbar {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.draw-canvas {
+  border: 2px dashed rgba(60, 80, 255, 0.4);
+  border-radius: var(--radius-lg);
+  background: #fff;
+  width: 100%;
+  max-width: 960px;
+  height: 480px;
+  touch-action: none;
+}
+
+.color-swatch {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+}
+
+.color-swatch.active {
+  border-color: #000;
+}
+
+/* Analytics */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.analytics-card {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+}
+
+canvas.chart {
+  width: 100%;
+  height: 180px;
+}
+
+/* Calm down mode */
+.calm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(56, 74, 192, 0.8);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 2rem;
+  animation: pulse 4s ease-in-out infinite;
+  z-index: 300;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.gallery-grid img {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(15, 26, 42, 0.12);
+}
+
+.story-panel {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  box-shadow: 0 4px 12px rgba(15, 26, 42, 0.08);
+}
+
+.story-panel span {
+  font-weight: 700;
+  display: inline-block;
+  margin-bottom: 0.25rem;
+}
+
+.bonus-body button {
+  margin-right: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+/* Responsive tweaks */
+@media (max-width: 960px) {
+  main {
+    padding: 1rem;
+  }
+
+  #view-container {
+    padding: 1.5rem;
+  }
+
+  .projector-status {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 600px) {
+  #teacher-tabs {
+    grid-auto-columns: minmax(140px, 1fr);
+  }
+
+  button {
+    padding: 0.75rem 1rem;
+  }
+}

--- a/ozge/data/demo-rosters.json
+++ b/ozge/data/demo-rosters.json
@@ -1,0 +1,32 @@
+{
+  "5A": {
+    "groups": {
+      "A": ["Ada", "Baran", "Cem"],
+      "B": ["Deniz", "Elif", "Fikri"],
+      "C": ["Gul", "Harun", "Ipek"],
+      "D": ["Jale", "Kerem", "Lara"]
+    },
+    "schedule": ["Monday 09:00", "Wednesday 09:00"],
+    "attendance": {}
+  },
+  "5B": {
+    "groups": {
+      "E": ["Mert", "Naz", "Okan"],
+      "F": ["Peri", "Rana", "Sami"],
+      "G": ["Tuna", "Umut", "Vera"],
+      "H": ["Yasmin", "Zehra", "Ali"]
+    },
+    "schedule": ["Tuesday 11:00", "Thursday 11:00"],
+    "attendance": {}
+  },
+  "5C": {
+    "groups": {},
+    "schedule": [],
+    "attendance": {}
+  },
+  "5D": {
+    "groups": {},
+    "schedule": [],
+    "attendance": {}
+  }
+}

--- a/ozge/data/demo-units.json
+++ b/ozge/data/demo-units.json
@@ -1,0 +1,26 @@
+{
+  "5A": [
+    {
+      "id": "u1",
+      "title": "Unit 1 – Classroom Language",
+      "modeMap": ["QUIZ", "DRAW", "SPEAK"],
+      "words": [
+        {"term": "pencil", "definition": "a tool for writing"},
+        {"term": "notebook", "definition": "a book of blank pages"},
+        {"term": "eraser", "definition": "a rubber for removing pencil marks"}
+      ],
+      "summary": [
+        "Students ask for help politely.",
+        "Review materials and classroom objects.",
+        "Practice short requests."
+      ],
+      "mcqs": [
+        {"question": "What do you use to write notes?", "options": ["pencil", "glue", "marker", "paint"], "answer": 0},
+        {"question": "Which word means clean mistakes?", "options": ["notebook", "eraser", "stapler", "board"], "answer": 1}
+      ]
+    }
+  ],
+  "5B": [],
+  "5C": [],
+  "5D": []
+}

--- a/ozge/data/stopwords.json
+++ b/ozge/data/stopwords.json
@@ -1,0 +1,3 @@
+[
+  "a", "an", "the", "and", "or", "but", "is", "are", "to", "of", "in", "on", "for", "with", "as", "at", "by", "be", "this", "that", "it", "from"
+]

--- a/ozge/exe/main.js
+++ b/ozge/exe/main.js
@@ -1,0 +1,33 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.removeMenu();
+  win.loadFile(path.join(__dirname, '..', 'index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/ozge/exe/preload.js
+++ b/ozge/exe/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge } = require('electron');
+
+contextBridge.exposeInMainWorld('ozgeDesktop', {
+  platform: process.platform
+});

--- a/ozge/index.html
+++ b/ozge/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Özge – Classroom Edition • Teacher Dashboard</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body data-role="teacher">
+  <div id="splash" class="view view-active" aria-hidden="false">
+    <div class="splash-inner">
+      <svg class="logo" aria-hidden="true">
+        <use href="assets/icons.svg#logo"></use>
+      </svg>
+      <h1>Özge – Classroom Edition</h1>
+      <p class="tagline">Offline-ready classroom control hub</p>
+      <button id="enter-app" class="primary" aria-label="Enter dashboard">Enter Classroom</button>
+    </div>
+  </div>
+
+  <header id="main-header" class="hidden" aria-label="Teacher controls">
+    <div class="brand">
+      <svg aria-hidden="true"><use href="assets/icons.svg#logo"></use></svg>
+      <span>Özge – Teacher Dashboard</span>
+    </div>
+    <div class="class-switcher" role="navigation" aria-label="Class selection">
+      <button class="class-chip" data-class="5A">5A</button>
+      <button class="class-chip" data-class="5B">5B</button>
+      <button class="class-chip" data-class="5C">5C</button>
+      <button class="class-chip" data-class="5D">5D</button>
+    </div>
+    <div class="session-controls">
+      <span class="active-class" aria-live="polite">Class: <strong>—</strong></span>
+      <button id="start-projector" class="ghost" aria-label="Open projector view">Projector View</button>
+      <button id="emergency-stop" class="danger" aria-label="Emergency stop">Emergency STOP</button>
+    </div>
+  </header>
+
+  <main id="main" class="hidden" tabindex="-1">
+    <nav id="teacher-tabs" aria-label="Teacher navigation">
+      <button data-tab="HOME" class="tab active">Home</button>
+      <button data-tab="QUIZ" class="tab">Quiz</button>
+      <button data-tab="PUZZLE" class="tab">Puzzle</button>
+      <button data-tab="SPEAK" class="tab">Speak</button>
+      <button data-tab="STORY" class="tab">Story</button>
+      <button data-tab="DRAW" class="tab">Draw &amp; Spell</button>
+      <button data-tab="BONUS" class="tab">Bonus Game</button>
+      <button data-tab="CONTENT_MANAGER" class="tab">Content</button>
+      <button data-tab="ANALYTICS" class="tab">Analytics</button>
+      <button data-tab="LOG" class="tab">Lesson Log</button>
+      <button data-tab="SETTINGS" class="tab">Settings</button>
+      <button data-tab="CLASS" class="tab">Class Admin</button>
+    </nav>
+
+    <section id="view-container" aria-live="polite">
+      <article id="view-HOME" class="view view-active" data-mode="HOME">
+        <header class="mode-header">
+          <div>
+            <h2>Home</h2>
+            <p class="active-topic">Topic: <span data-bind="topic">—</span></p>
+          </div>
+          <div class="status-pill">
+            <span>Timer</span>
+            <span data-bind="timer">00:00</span>
+          </div>
+        </header>
+        <div class="home-grid" role="list">
+          <button class="home-card" data-launch="QUIZ">Vocabulary</button>
+          <button class="home-card" data-launch="PUZZLE">Grammar</button>
+          <button class="home-card" data-launch="SPEAK">Speaking</button>
+          <button class="home-card" data-launch="STORY">Story</button>
+          <button class="home-card" data-launch="BONUS">Final Test</button>
+          <button class="home-card" data-launch="DRAW">Draw &amp; Spell</button>
+        </div>
+        <section class="scoreboard" aria-label="Group scores">
+          <header>
+            <h3>Groups</h3>
+            <button class="ghost" id="edit-avatars">Avatars</button>
+          </header>
+          <div class="groups" id="group-list"></div>
+        </section>
+      </article>
+
+      <article id="view-QUIZ" class="view" data-mode="QUIZ"></article>
+      <article id="view-PUZZLE" class="view" data-mode="PUZZLE"></article>
+      <article id="view-SPEAK" class="view" data-mode="SPEAK"></article>
+      <article id="view-STORY" class="view" data-mode="STORY"></article>
+      <article id="view-DRAW" class="view" data-mode="DRAW"></article>
+      <article id="view-BONUS" class="view" data-mode="BONUS"></article>
+      <article id="view-CONTENT_MANAGER" class="view" data-mode="CONTENT_MANAGER"></article>
+      <article id="view-ANALYTICS" class="view" data-mode="ANALYTICS"></article>
+      <article id="view-LOG" class="view" data-mode="LOG"></article>
+      <article id="view-SETTINGS" class="view" data-mode="SETTINGS"></article>
+      <article id="view-CLASS" class="view" data-mode="CLASS"></article>
+      <article id="view-RESULT" class="view" data-mode="RESULT"></article>
+    </section>
+  </main>
+
+  <div id="pin-dialog" role="dialog" aria-modal="true" hidden>
+    <div class="dialog">
+      <h2>Enter PIN</h2>
+      <p>This action requires verification.</p>
+      <input id="pin-input" type="password" maxlength="4" aria-label="PIN" autocomplete="one-time-code">
+      <div class="dialog-actions">
+        <button id="pin-cancel" class="ghost">Cancel</button>
+        <button id="pin-confirm" class="primary">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <template id="group-card-template">
+    <article class="group-card" data-group="">
+      <header>
+        <span class="avatar" aria-hidden="true">😀</span>
+        <h4 data-field="name"></h4>
+      </header>
+      <dl>
+        <div><dt>Score</dt><dd data-field="score">0</dd></div>
+        <div><dt>Behavior</dt><dd data-field="behavior">Balanced</dd></div>
+      </dl>
+      <div class="behavior-controls" role="group" aria-label="Behavior controls">
+        <button data-action="positive">🟢</button>
+        <button data-action="warning">🟠</button>
+        <button data-action="penalty">🔴</button>
+      </div>
+      <button class="ghost" data-action="attendance">Attendance</button>
+    </article>
+  </template>
+
+  <script src="js/state.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/ui.js"></script>
+  <script src="js/storage.js"></script>
+  <script src="js/ocr.js"></script>
+  <script src="js/content.js"></script>
+  <script src="js/speech.js"></script>
+  <script src="js/analytics.js"></script>
+  <script src="js/quiz.js"></script>
+  <script src="js/puzzle.js"></script>
+  <script src="js/story.js"></script>
+  <script src="js/draw.js"></script>
+  <script src="js/bonus.js"></script>
+  <script src="js/core.js"></script>
+</body>
+</html>

--- a/ozge/js/analytics.js
+++ b/ozge/js/analytics.js
@@ -1,0 +1,146 @@
+(function () {
+  function calculate(cls) {
+    const modeCounts = {};
+    cls.lessonLog.forEach((entry) => {
+      const mode = entry.mode || "HOME";
+      if (!modeCounts[mode]) {
+        modeCounts[mode] = { correct: 0, total: 0 };
+      }
+      modeCounts[mode].correct += entry.correct || 0;
+      modeCounts[mode].total += entry.total || 0;
+    });
+
+    const behaviorTrend = cls.behaviorLog.slice(-50).map((item) => ({
+      time: item.timestamp,
+      value: item.action === "positive" ? 5 : item.action === "penalty" ? -10 : 0
+    }));
+
+    const difficultWords = {};
+    cls.lessonLog.forEach((entry) => {
+      (entry.missedWords || []).forEach((word) => {
+        difficultWords[word] = (difficultWords[word] || 0) + 1;
+      });
+    });
+
+    return {
+      modeCounts,
+      behaviorTrend,
+      difficultWords: Object.entries(difficultWords)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 10)
+    };
+  }
+
+  function render(container, cls) {
+    container.innerHTML = `
+      <section class="analytics-grid">
+        <article class="analytics-card" id="chart-modes">
+          <h3>Accuracy by Mode</h3>
+          <canvas class="chart" data-chart="mode"></canvas>
+        </article>
+        <article class="analytics-card" id="chart-words">
+          <h3>Most Missed Words</h3>
+          <ul class="word-frequency"></ul>
+        </article>
+        <article class="analytics-card" id="chart-behavior">
+          <h3>Behavior Over Time</h3>
+          <canvas class="chart" data-chart="behavior"></canvas>
+        </article>
+        <article class="analytics-card">
+          <h3>Export</h3>
+          <button id="analytics-export-json" class="ghost">Download JSON</button>
+          <button id="analytics-export-csv" class="ghost">Download CSV</button>
+          <button id="analytics-print" class="primary">Print/PDF</button>
+        </article>
+      </section>
+    `;
+
+    const data = calculate(cls);
+    drawModeChart(container.querySelector('[data-chart="mode"]'), data.modeCounts);
+    drawBehaviorChart(container.querySelector('[data-chart="behavior"]'), data.behaviorTrend);
+    renderWordList(container.querySelector('.word-frequency'), data.difficultWords);
+
+    container.querySelector('#analytics-export-json').addEventListener('click', () => exportJSON(cls, data));
+    container.querySelector('#analytics-export-csv').addEventListener('click', () => exportCSV(cls, data));
+    container.querySelector('#analytics-print').addEventListener('click', () => window.print());
+  }
+
+  function drawModeChart(canvas, modeCounts) {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const modes = Object.keys(modeCounts);
+    if (!modes.length) {
+      ctx.fillText('No data yet', 10, 30);
+      return;
+    }
+    const width = canvas.width || canvas.offsetWidth;
+    const height = canvas.height || canvas.offsetHeight;
+    const barWidth = width / (modes.length * 1.5);
+    modes.forEach((mode, index) => {
+      const stats = modeCounts[mode];
+      const ratio = stats.total ? stats.correct / stats.total : 0;
+      const barHeight = ratio * (height - 20);
+      ctx.fillStyle = '#3c50ff';
+      ctx.fillRect(20 + index * barWidth * 1.5, height - barHeight - 10, barWidth, barHeight);
+      ctx.fillStyle = '#0f1a2a';
+      ctx.fillText(`${mode} ${(ratio * 100).toFixed(0)}%`, 20 + index * barWidth * 1.5, height - 2);
+    });
+  }
+
+  function drawBehaviorChart(canvas, trend) {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (!trend.length) {
+      ctx.fillText('No behavior entries yet', 10, 30);
+      return;
+    }
+    const width = canvas.width || canvas.offsetWidth;
+    const height = canvas.height || canvas.offsetHeight;
+    ctx.beginPath();
+    ctx.moveTo(0, height / 2);
+    trend.forEach((item, index) => {
+      const x = (index / Math.max(1, trend.length - 1)) * width;
+      const y = height / 2 - item.value * 2;
+      ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = '#ffba3b';
+    ctx.lineWidth = 3;
+    ctx.stroke();
+  }
+
+  function renderWordList(list, entries) {
+    if (!list) return;
+    list.innerHTML = entries.map(([word, count]) => `<li>${word} <strong>${count}</strong></li>`).join('');
+  }
+
+  function exportJSON(cls, data) {
+    const blob = new Blob([JSON.stringify({ classId: cls.id, generatedAt: new Date().toISOString(), data }, null, 2)], { type: 'application/json' });
+    downloadBlob(blob, `${cls.id}-analytics.json`);
+  }
+
+  function exportCSV(cls, data) {
+    const rows = ['mode,accuracy'];
+    Object.entries(data.modeCounts).forEach(([mode, stats]) => {
+      const ratio = stats.total ? stats.correct / stats.total : 0;
+      rows.push(`${mode},${(ratio * 100).toFixed(0)}`);
+    });
+    const blob = new Blob([rows.join('\n')], { type: 'text/csv' });
+    downloadBlob(blob, `${cls.id}-analytics.csv`);
+  }
+
+  function downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  window.Analytics = {
+    render,
+    calculate
+  };
+})();

--- a/ozge/js/bonus.js
+++ b/ozge/js/bonus.js
@@ -1,0 +1,149 @@
+(function () {
+  let container = null;
+  let interval = null;
+  let timeLeft = 0;
+  let currentQuestion = null;
+  let streak = 0;
+
+  function render(view, cls) {
+    container = view;
+    container.innerHTML = `
+      <header class="mode-header">
+        <div>
+          <h2>Bonus Blitz</h2>
+          <p>Rapid-fire questions. Double points for correct answers!</p>
+        </div>
+        <button id="bonus-start" class="primary">Start Blitz</button>
+      </header>
+      <section class="bonus-body">
+        <div class="bonus-status">Time left: <span data-field="time">0</span>s • Streak: <span data-field="streak">0</span></div>
+        <div class="bonus-question" data-field="question">Press start to begin.</div>
+        <div class="bonus-options" data-field="options"></div>
+        <div class="bonus-group">
+          <label for="bonus-group-select">Answering group</label>
+          <select id="bonus-group-select"></select>
+        </div>
+      </section>
+    `;
+    container.querySelector('#bonus-start').addEventListener('click', () => start(cls));
+    populateGroupSelect(cls);
+  }
+
+  function populateGroupSelect(cls) {
+    const select = container.querySelector('#bonus-group-select');
+    select.innerHTML = '';
+    Object.keys(cls.roster.groups).forEach((group) => {
+      const option = document.createElement('option');
+      option.value = group;
+      option.textContent = group;
+      if (group === cls.current.activeGroup) option.selected = true;
+      select.appendChild(option);
+    });
+  }
+
+  function start(cls) {
+    clearInterval(interval);
+    timeLeft = (State.store.settings.bonusDuration || 30);
+    streak = 0;
+    updateTime();
+    nextQuestion(cls);
+    interval = setInterval(() => {
+      timeLeft -= 1;
+      updateTime();
+      if (timeLeft <= 0) {
+        clearInterval(interval);
+        container.querySelector('[data-field="question"]').textContent = 'Bonus round finished!';
+        container.querySelector('[data-field="options"]').innerHTML = '';
+      }
+    }, 1000);
+  }
+
+  function updateTime() {
+    const timeEl = container.querySelector('[data-field="time"]');
+    if (timeEl) timeEl.textContent = timeLeft;
+    const streakEl = container.querySelector('[data-field="streak"]');
+    if (streakEl) streakEl.textContent = streak;
+  }
+
+  function nextQuestion(cls) {
+    const pool = buildQuestions(cls);
+    currentQuestion = pool[Math.floor(Math.random() * pool.length)];
+    const questionEl = container.querySelector('[data-field="question"]');
+    const optionsEl = container.querySelector('[data-field="options"]');
+    questionEl.textContent = currentQuestion.prompt;
+    optionsEl.innerHTML = '';
+    currentQuestion.options.forEach((option, index) => {
+      const button = document.createElement('button');
+      button.textContent = option;
+      button.addEventListener('click', () => handleAnswer(index, cls));
+      optionsEl.appendChild(button);
+    });
+  }
+
+  function handleAnswer(index, cls) {
+    const correct = index === currentQuestion.answer;
+    if (correct) {
+      streak += 1;
+      const group = container.querySelector('#bonus-group-select').value;
+      awardPoints(cls, group, 20 + streak * 2);
+      nextQuestion(cls);
+    } else {
+      streak = 0;
+      updateTime();
+    }
+  }
+
+  function buildQuestions(cls) {
+    const units = cls.units;
+    if (!units.length) {
+      return [
+        { prompt: 'Spell the word for a writing tool.', options: ['pencil', 'glue', 'scissors'], answer: 0 }
+      ];
+    }
+    const questions = [];
+    units.forEach((unit) => {
+      (unit.words || []).forEach((word) => {
+        const options = shuffle([word.term, ...randomWords(units, 2, word.term)]);
+        questions.push({
+          prompt: `Which word fits: ${word.definition}?`,
+          options,
+          answer: Math.max(0, options.indexOf(word.term))
+        });
+      });
+    });
+    return questions.slice(0, 60);
+  }
+
+  function randomWords(units, count, exclude) {
+    const pool = [];
+    units.forEach((unit) => {
+      unit.words.forEach((word) => {
+        if (word.term !== exclude) pool.push(word.term);
+      });
+    });
+    return shuffle(pool).slice(0, count);
+  }
+
+  function awardPoints(cls, group, points) {
+    const g = cls.roster.groups[group];
+    if (g) {
+      g.score += points;
+      State.persist();
+      UI.renderGroups(document.getElementById('group-list'), cls);
+      Sync.emit('score', { classId: cls.id, group, score: g.score });
+    }
+  }
+
+  function shuffle(list) {
+    const arr = list.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  window.Bonus = {
+    render
+  };
+})();

--- a/ozge/js/content.js
+++ b/ozge/js/content.js
@@ -1,0 +1,574 @@
+(function () {
+  const DEFAULT_STOPWORDS = [
+    "the",
+    "and",
+    "for",
+    "with",
+    "this",
+    "that",
+    "have",
+    "from",
+    "your",
+    "about",
+    "into",
+    "after",
+    "before",
+    "because",
+    "once",
+    "where",
+    "while",
+    "which",
+    "should",
+    "would",
+    "could"
+  ];
+
+  let stopwordList = [];
+  let stopwordLoaded = false;
+  let viewInitialized = false;
+  let currentUnits = [];
+
+  function $(selector, root = document) {
+    return root.querySelector(selector);
+  }
+
+  function createView(container) {
+    container.innerHTML = `
+      <section class="content-import">
+        <h2>Content Manager</h2>
+        <p>Import PDFs or images. Files stay on this device.</p>
+        <label class="ghost">
+          <input type="file" id="content-input" accept="application/pdf,image/*" multiple hidden>
+          <span>Choose Files</span>
+        </label>
+        <div id="content-drop" class="drop-zone" aria-label="Drop files here">Drop files here</div>
+      </section>
+      <section>
+        <h3>Image Previews &amp; Crop</h3>
+        <div id="content-preview" class="preview-grid"></div>
+      </section>
+      <section>
+        <h3>Detected Units</h3>
+        <div id="unit-table"></div>
+      </section>
+      <section>
+        <h3>Unit → Mode Mapping</h3>
+        <div id="unit-mapping"></div>
+      </section>
+      <section class="pack-actions">
+        <button id="save-pack" class="primary">Save Unit Pack</button>
+        <input id="load-pack" type="file" accept="application/json" hidden>
+        <button id="load-pack-btn" class="ghost">Load Unit Pack</button>
+      </section>
+      <section>
+        <h3>Stored Files</h3>
+        <p class="caption">Imported PDFs and images are saved to this device for offline reuse.</p>
+        <div id="stored-files" class="stored-files" aria-live="polite"></div>
+      </section>
+    `;
+
+    const input = $("#content-input", container);
+    const drop = $("#content-drop", container);
+    const loadBtn = $("#load-pack-btn", container);
+    const loadInput = $("#load-pack", container);
+
+    input.addEventListener("change", async (event) => {
+      const files = Array.from(event.target.files || []);
+      await processFiles(files);
+    });
+
+    ;["dragenter", "dragover"].forEach((type) => {
+      drop.addEventListener(type, (event) => {
+        event.preventDefault();
+        drop.classList.add("dragging");
+      });
+    });
+    ;["dragleave", "drop"].forEach((type) => {
+      drop.addEventListener(type, (event) => {
+        event.preventDefault();
+        drop.classList.remove("dragging");
+      });
+    });
+    drop.addEventListener("drop", async (event) => {
+      const files = Array.from(event.dataTransfer.files || []);
+      await processFiles(files);
+    });
+
+    $("#save-pack", container).addEventListener("click", savePack);
+    loadBtn.addEventListener("click", () => loadInput.click());
+    loadInput.addEventListener("change", importPack);
+
+    viewInitialized = true;
+  }
+
+  function render(container, cls) {
+    if (!viewInitialized) {
+      createView(container);
+    }
+    currentUnits = cls.units.slice();
+    renderUnitTable(cls);
+    renderMapping(cls);
+    renderStoredFiles(cls);
+  }
+
+  async function ensureStopwords() {
+    if (stopwordLoaded) return stopwordList;
+    try {
+      const response = await fetch("data/stopwords.json");
+      if (!response.ok) throw new Error("stopwords fetch failed");
+      stopwordList = await response.json();
+    } catch (error) {
+      console.warn("Falling back to default stopwords", error);
+      stopwordList = DEFAULT_STOPWORDS.slice();
+    }
+    stopwordLoaded = true;
+    return stopwordList;
+  }
+
+  async function processFiles(files) {
+    if (!files.length) return;
+    await ensureStopwords();
+    const cls = State.getActiveClass();
+    for (const file of files) {
+      let text = "";
+      if (file.type && file.type.startsWith('image/')) {
+        text = await handleImageFile(file);
+      } else {
+        text = await OCR.run(file);
+      }
+      await ingestText(text);
+      try {
+        await ContentDB.storeImportedFile(cls.id, file, {
+          textPreview: (text || "").slice(0, 280)
+        });
+      } catch (error) {
+        console.warn("Failed to store file", error);
+      }
+    }
+    cls.units = currentUnits;
+    State.persist();
+    renderUnitTable(cls);
+    renderMapping(cls);
+    renderStoredFiles(cls);
+    Sync.emit("units", { classId: cls.id, units: currentUnits });
+  }
+
+  async function ingestText(text) {
+    if (!text) return;
+    await ensureStopwords();
+    const units = parseUnits(text, stopwordList);
+    mergeUnits(units);
+  }
+
+  function parseUnits(text, stopwords) {
+    const blocks = text.split(/\n\s*/g);
+    const units = [];
+    let active = null;
+    blocks.forEach((block) => {
+      const clean = block.trim();
+      if (!clean) return;
+      if (/^(unit|lesson)\s+\d+/i.test(clean)) {
+        if (active) {
+          units.push(active);
+        }
+        active = {
+          id: crypto.randomUUID(),
+          title: clean,
+          words: [],
+          raw: ""
+        };
+        return;
+      }
+      if (!active) {
+        active = {
+          id: crypto.randomUUID(),
+          title: "Unit",
+          words: [],
+          raw: ""
+        };
+      }
+      active.raw += clean + "\n";
+      const words = clean
+        .toLowerCase()
+        .replace(/[^a-z\s]/g, " ")
+        .split(/\s+/)
+        .filter((w) => w.length > 2 && !stopwords.includes(w));
+      const freq = countFrequency(words);
+      Object.entries(freq).forEach(([term, count]) => {
+        if (!active.words.some((item) => item.term === term)) {
+          active.words.push({ term, count });
+        } else {
+          const existing = active.words.find((item) => item.term === term);
+          existing.count += count;
+        }
+      });
+    });
+    if (active) units.push(active);
+    return units.map((u) => ({
+      id: u.id,
+      title: u.title,
+      words: u.words
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 15)
+        .map(({ term, count }) => ({ term, definition: `Common classroom word (${count})` })),
+      summary: createSummary(u.raw),
+      mcqs: createMCQs(u.words)
+    }));
+  }
+
+  async function handleImageFile(file) {
+    const preview = document.getElementById("content-preview");
+    if (!preview) return OCR.run(file);
+    const wrapper = document.createElement("article");
+    wrapper.className = "preview-card";
+    const title = document.createElement("header");
+    title.textContent = file.name;
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    const controls = document.createElement("div");
+    controls.className = "crop-controls";
+    const topRange = document.createElement("input");
+    topRange.type = "range";
+    topRange.min = 0;
+    topRange.max = 40;
+    topRange.value = 0;
+    const bottomRange = document.createElement("input");
+    bottomRange.type = "range";
+    bottomRange.min = 0;
+    bottomRange.max = 40;
+    bottomRange.value = 0;
+    const applyBtn = document.createElement("button");
+    applyBtn.textContent = "Apply Crop OCR";
+    applyBtn.className = "ghost";
+    const output = document.createElement("pre");
+    output.className = "ocr-output";
+    const topLabel = document.createElement("label");
+    topLabel.textContent = "Top";
+    topLabel.appendChild(topRange);
+    const bottomLabel = document.createElement("label");
+    bottomLabel.textContent = "Bottom";
+    bottomLabel.appendChild(bottomRange);
+    controls.appendChild(topLabel);
+    controls.appendChild(bottomLabel);
+    controls.appendChild(applyBtn);
+    wrapper.appendChild(title);
+    wrapper.appendChild(canvas);
+    wrapper.appendChild(controls);
+    wrapper.appendChild(output);
+    preview.appendChild(wrapper);
+
+    const bitmap = await createImageBitmap(file);
+    const scale = Math.min(400 / bitmap.width, 1);
+    canvas.width = Math.round(bitmap.width * scale);
+    canvas.height = Math.round(bitmap.height * scale);
+
+    function drawOverlay() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      const top = (Number(topRange.value) / 100) * canvas.height;
+      const bottom = (Number(bottomRange.value) / 100) * canvas.height;
+      ctx.fillStyle = "rgba(0,0,0,0.3)";
+      if (top > 0) ctx.fillRect(0, 0, canvas.width, top);
+      if (bottom > 0) ctx.fillRect(0, canvas.height - bottom, canvas.width, bottom);
+    }
+
+    topRange.addEventListener("input", drawOverlay);
+    bottomRange.addEventListener("input", drawOverlay);
+
+    async function runCrop() {
+      const topPercent = Number(topRange.value) / 100;
+      const bottomPercent = Number(bottomRange.value) / 100;
+      const cropHeight = bitmap.height * (1 - topPercent - bottomPercent);
+      const offsetY = bitmap.height * topPercent;
+      const off = document.createElement("canvas");
+      off.width = bitmap.width;
+      off.height = Math.max(1, Math.round(cropHeight));
+      const offCtx = off.getContext("2d");
+      offCtx.drawImage(bitmap, 0, offsetY, bitmap.width, cropHeight, 0, 0, off.width, off.height);
+      const blob = await new Promise((resolve) => off.toBlob(resolve, file.type || "image/png"));
+      const croppedFile = new File([blob], file.name, { type: file.type || "image/png" });
+      const text = await OCR.run(croppedFile);
+      output.textContent = text || "(no text detected)";
+      return text;
+    }
+
+    applyBtn.addEventListener("click", async () => {
+      const text = await runCrop();
+      await ingestText(text);
+      const cls = State.getActiveClass();
+      cls.units = currentUnits;
+      State.persist();
+      renderUnitTable(cls);
+      renderMapping(cls);
+    });
+
+    drawOverlay();
+    const initialText = await runCrop();
+    return initialText;
+  }
+
+  function countFrequency(words) {
+    return words.reduce((acc, word) => {
+      acc[word] = (acc[word] || 0) + 1;
+      return acc;
+    }, {});
+  }
+
+  function createSummary(raw) {
+    if (!raw) return ["Text not available"];
+    const sentences = raw.split(/[.!?]/).map((s) => s.trim()).filter(Boolean);
+    return sentences.slice(0, 3);
+  }
+
+  function difficultyFromWord(word) {
+    if (word.length <= 4) return "easy";
+    if (word.length <= 7) return "medium";
+    return "hard";
+  }
+
+  function createMCQs(words) {
+    const sorted = words.sort((a, b) => b.count - a.count).slice(0, 8);
+    const mcqs = [];
+    for (let i = 0; i < Math.min(5, sorted.length); i++) {
+      const correct = sorted[i];
+      const distractors = sorted
+        .filter((item) => item.term !== correct.term)
+        .slice(0, 3)
+        .map((item) => item.term);
+      const options = shuffle([correct.term, ...distractors]);
+      mcqs.push({
+        question: `Choose the word related to ${correct.term}`,
+        options,
+        answer: options.indexOf(correct.term),
+        difficulty: difficultyFromWord(correct.term)
+      });
+    }
+    return mcqs;
+  }
+
+  function shuffle(list) {
+    const arr = list.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function mergeUnits(units) {
+    units.forEach((unit) => {
+      const existing = currentUnits.find((u) => u.title === unit.title);
+      if (existing) {
+        existing.words = mergeWordLists(existing.words, unit.words);
+        existing.summary = unit.summary;
+        existing.mcqs = unit.mcqs;
+      } else {
+        currentUnits.push({
+          ...unit,
+          modeMap: ["QUIZ", "PUZZLE", "SPEAK", "STORY", "DRAW"]
+        });
+      }
+    });
+  }
+
+  function mergeWordLists(a, b) {
+    const map = new Map();
+    a.forEach((item) => map.set(item.term, item));
+    b.forEach((item) => {
+      if (map.has(item.term)) {
+        map.get(item.term).definition = item.definition;
+      } else {
+        map.set(item.term, item);
+      }
+    });
+    return Array.from(map.values());
+  }
+
+  function renderUnitTable(cls) {
+    const table = document.getElementById("unit-table");
+    if (!table) return;
+    table.innerHTML = "";
+    if (!currentUnits.length) {
+      table.innerHTML = `<p>No units detected yet.</p>`;
+      return;
+    }
+    currentUnits.forEach((unit) => {
+      const card = document.createElement("article");
+      card.className = "unit-card";
+      card.innerHTML = `
+        <header>
+          <h4 contenteditable="true" data-field="title">${unit.title}</h4>
+          <button class="ghost" data-action="remove">Remove</button>
+        </header>
+        <p>${unit.summary.join(" • ")}</p>
+        <ul class="word-list">
+          ${unit.words.map((w) => `<li>${w.term} <span>${w.definition}</span></li>`).join("")}
+        </ul>
+      `;
+      card.querySelector('[data-field="title"]').addEventListener("blur", (event) => {
+        unit.title = event.target.textContent.trim();
+        State.upsertUnit(unit);
+      });
+      card.querySelector('[data-action="remove"]').addEventListener("click", () => {
+        currentUnits = currentUnits.filter((item) => item.id !== unit.id);
+        const cls = State.getActiveClass();
+        cls.units = currentUnits;
+        State.persist();
+        renderUnitTable(cls);
+        renderMapping(cls);
+      });
+      table.appendChild(card);
+    });
+  }
+
+  function renderMapping(cls) {
+    const container = document.getElementById("unit-mapping");
+    if (!container) return;
+    container.innerHTML = "";
+    const modes = ["QUIZ", "PUZZLE", "SPEAK", "STORY", "DRAW"];
+    modes.forEach((mode) => {
+      const section = document.createElement("section");
+      section.className = "mode-chip-row";
+      const title = document.createElement("h4");
+      title.textContent = mode;
+      section.appendChild(title);
+      const row = document.createElement("div");
+      row.className = "chip-row";
+      currentUnits.forEach((unit) => {
+        const chip = document.createElement("button");
+        chip.className = "chip";
+        chip.textContent = unit.title;
+        const selected = (cls.unitSelections[mode] || []).includes(unit.id);
+        chip.classList.toggle("active", selected);
+        chip.addEventListener("click", () => {
+          const list = cls.unitSelections[mode] || [];
+          const idx = list.indexOf(unit.id);
+          if (idx >= 0) {
+            list.splice(idx, 1);
+          } else {
+            list.push(unit.id);
+          }
+          State.setUnitSelection(mode, list);
+          renderMapping(cls);
+        });
+        row.appendChild(chip);
+      });
+      section.appendChild(row);
+      container.appendChild(section);
+    });
+  }
+
+  function savePack() {
+    const cls = State.getActiveClass();
+    const pack = {
+      classId: cls.id,
+      generatedAt: new Date().toISOString(),
+      units: currentUnits
+    };
+    const blob = new Blob([JSON.stringify(pack, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${cls.id}-unit-pack.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function importPack(event) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const json = JSON.parse(await file.text());
+      currentUnits = json.units || [];
+      const cls = State.getActiveClass();
+      cls.units = currentUnits;
+      State.persist();
+      renderUnitTable(cls);
+      renderMapping(cls);
+    } catch (err) {
+      alert("Unable to load pack");
+    }
+  }
+
+  async function renderStoredFiles(cls) {
+    const container = document.getElementById("stored-files");
+    if (!container || !window.ContentDB) return;
+    container.textContent = "Loading files…";
+    try {
+      const files = await ContentDB.listFiles(cls.id);
+      if (!files.length) {
+        container.textContent = "No stored files yet. Import PDFs or images to keep them here.";
+        return;
+      }
+      container.innerHTML = "";
+      files.forEach((file) => {
+        container.appendChild(createFileCard(file));
+      });
+    } catch (error) {
+      console.warn("Unable to list stored files", error);
+      container.textContent = "Storage unavailable in this browser.";
+    }
+  }
+
+  function createFileCard(file) {
+    const article = document.createElement("article");
+    article.className = "stored-file";
+    const header = document.createElement("header");
+    const title = document.createElement("h4");
+    title.textContent = file.name;
+    header.appendChild(title);
+    const meta = document.createElement("p");
+    meta.className = "meta";
+    const sizeKb = Math.max(1, Math.round(file.size / 1024));
+    const date = new Date(file.addedAt);
+    meta.textContent = `${sizeKb} KB • ${date.toLocaleString()}`;
+    const preview = document.createElement("p");
+    preview.className = "preview";
+    preview.textContent = file.textPreview ? `${file.textPreview.trim()}…` : "(No text preview captured)";
+    const actions = document.createElement("div");
+    actions.className = "actions";
+    const download = document.createElement("button");
+    download.className = "ghost";
+    download.textContent = "Download";
+    download.addEventListener("click", () => downloadFile(file.id, file.name));
+    const remove = document.createElement("button");
+    remove.className = "danger";
+    remove.textContent = "Delete";
+    remove.addEventListener("click", async () => {
+      if (!confirm(`Remove ${file.name} from this device?`)) return;
+      await ContentDB.deleteFile(file.id);
+      const cls = State.getActiveClass();
+      renderStoredFiles(cls);
+    });
+    actions.appendChild(download);
+    actions.appendChild(remove);
+    article.appendChild(header);
+    article.appendChild(meta);
+    article.appendChild(preview);
+    article.appendChild(actions);
+    return article;
+  }
+
+  async function downloadFile(id, name) {
+    try {
+      const record = await ContentDB.getFile(id);
+      if (!record || !record.blob) {
+        alert("File not found in storage.");
+        return;
+      }
+      const url = URL.createObjectURL(record.blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = name;
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 2000);
+    } catch (error) {
+      console.warn("Download failed", error);
+      alert("Could not download the stored file. Try again later.");
+    }
+  }
+
+  window.ContentManager = {
+    render
+  };
+})();

--- a/ozge/js/core.js
+++ b/ozge/js/core.js
@@ -1,0 +1,552 @@
+(function () {
+  const bodyRole = document.body.dataset.role || 'teacher';
+  let projectorWindow = null;
+  let autoBonusTimer = null;
+  let calmOverlay = null;
+
+  function initTeacher() {
+    UI.toggleHeader(false);
+    document.getElementById('enter-app').addEventListener('click', enterDashboard);
+    document.getElementById('start-projector').addEventListener('click', openProjector);
+    document.getElementById('emergency-stop').addEventListener('click', emergencyStop);
+    setupTabs();
+    setupHomeActions();
+    setupBehaviorControls();
+    setupPinDialog();
+    setInterval(updateTimer, 1000);
+  }
+
+  function initProjector() {
+    UI.setProjectorSection('projector-home');
+    Sync.on(handleProjectorMessage);
+    const snapshot = Sync.loadSnapshot();
+    if (snapshot) {
+      applySnapshot(snapshot);
+    }
+  }
+
+  function enterDashboard() {
+    UI.toggleHeader(true);
+    document.getElementById('splash').classList.remove('view-active');
+    document.getElementById('splash').setAttribute('aria-hidden', 'true');
+    document.getElementById('main').focus();
+    State.ready.then(() => {
+      const cls = State.getActiveClass();
+      if (!cls.lastPenalty) cls.lastPenalty = Date.now();
+      updateActiveClass(cls.id);
+      renderActiveTab('HOME');
+      scheduleAutoBonus(cls);
+    });
+  }
+
+  function updateActiveClass(id) {
+    const header = document.querySelector('.active-class strong');
+    if (header) header.textContent = id;
+    document.querySelectorAll('.class-chip').forEach((chip) => {
+      chip.classList.toggle('active', chip.dataset.class === id);
+      chip.addEventListener('click', () => {
+        State.setActiveClass(chip.dataset.class);
+        const cls = State.getActiveClass();
+        UI.renderHome(cls);
+        renderActiveTab(currentTab);
+        Sync.emit('class-change', { id: cls.id });
+        scheduleAutoBonus(cls);
+      });
+    });
+    const cls = State.getActiveClass();
+    if (!cls.current.unitId && cls.units.length) {
+      cls.current.unitId = cls.units[0].id;
+    }
+    UI.renderHome(cls);
+    UI.renderProjectorHome(cls);
+  }
+
+  let currentTab = 'HOME';
+
+  function setupTabs() {
+    document.querySelectorAll('#teacher-tabs .tab').forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const next = tab.dataset.tab;
+        renderActiveTab(next);
+      });
+    });
+  }
+
+  function renderActiveTab(tabId) {
+    currentTab = tabId;
+    UI.setActiveTab(tabId);
+    const cls = State.getActiveClass();
+    switch (tabId) {
+      case 'HOME':
+        UI.renderHome(cls);
+        break;
+      case 'QUIZ':
+        Quiz.render(document.getElementById('view-QUIZ'), cls);
+        break;
+      case 'PUZZLE':
+        Puzzle.render(document.getElementById('view-PUZZLE'), cls);
+        break;
+      case 'SPEAK':
+        renderSpeak(cls);
+        break;
+      case 'STORY':
+        Story.render(document.getElementById('view-STORY'), cls);
+        break;
+      case 'DRAW':
+        Draw.render(document.getElementById('view-DRAW'), cls);
+        break;
+      case 'BONUS':
+        Bonus.render(document.getElementById('view-BONUS'), cls);
+        break;
+      case 'CONTENT_MANAGER':
+        ContentManager.render(document.getElementById('view-CONTENT_MANAGER'), cls);
+        break;
+      case 'ANALYTICS':
+        Analytics.render(document.getElementById('view-ANALYTICS'), cls);
+        break;
+      case 'LOG':
+        renderLog(cls);
+        break;
+      case 'SETTINGS':
+        renderSettings();
+        break;
+      case 'CLASS':
+        renderClassAdmin(cls);
+        break;
+    }
+    cls.current.mode = tabId;
+    if (['HOME', 'QUIZ', 'PUZZLE', 'SPEAK', 'STORY', 'DRAW', 'BONUS', 'RESULT'].includes(tabId)) {
+      Sync.emit('mode-change', { mode: tabId });
+    }
+    Sync.saveSnapshot(buildSnapshot());
+  }
+
+  function renderSpeak(cls) {
+    const container = document.getElementById('view-SPEAK');
+    container.innerHTML = `
+      <header class="mode-header">
+        <div>
+          <h2>Speaking Spotlight</h2>
+          <p>Prompt students to repeat and score automatically.</p>
+        </div>
+        <button id="speak-start" class="primary">Start Practice</button>
+      </header>
+      <section class="speak-body">
+        <label>
+          Sentence prompt
+          <input id="speak-prompt" type="text" value="Please describe your classroom." />
+        </label>
+        <div class="speak-status">
+          <span>Speech engine: ${Speaking.available() ? 'Web Speech' : 'Simulated'}</span>
+          <span>Score: <strong data-field="score">0</strong></span>
+        </div>
+        <div class="speak-wave" aria-hidden="true"></div>
+        <button id="speak-award" class="ghost">Award +5</button>
+      </section>
+    `;
+    container.querySelector('#speak-start').addEventListener('click', () => startSpeaking(cls));
+    container.querySelector('#speak-award').addEventListener('click', () => awardSpeaking(cls));
+  }
+
+  function startSpeaking(cls) {
+    const prompt = document.getElementById('speak-prompt').value;
+    const scoreEl = document.querySelector('[data-field="score"]');
+    Speaking.startListening((result) => {
+      const score = result.score;
+      scoreEl.textContent = score;
+      State.addLessonLog({ mode: 'SPEAK', score, prompt });
+      if (score > 70) {
+        awardPoints(cls.current.activeGroup, 6);
+      }
+    }, (error) => {
+      console.warn('speech error', error);
+    });
+  }
+
+  function awardSpeaking(cls) {
+    awardPoints(cls.current.activeGroup, 5);
+    alert('Bonus points added!');
+  }
+
+  function awardPoints(group, points) {
+    const cls = State.getActiveClass();
+    const g = cls.roster.groups[group];
+    if (g) {
+      g.score += points;
+      State.persist();
+      UI.renderGroups(document.getElementById('group-list'), cls);
+      UI.renderProjectorHome(cls);
+      Sync.emit('score', { classId: cls.id, group, score: g.score });
+    }
+  }
+
+  function renderLog(cls) {
+    const container = document.getElementById('view-LOG');
+    container.innerHTML = `
+      <header class="mode-header">
+        <div>
+          <h2>Lesson Log</h2>
+          <p>Auto-tracked entries plus manual notes.</p>
+        </div>
+        <button id="log-export" class="ghost">Export JSON</button>
+      </header>
+      <section>
+        <textarea id="log-note" rows="4" placeholder="Add note"></textarea>
+        <button id="log-add" class="primary">Add Note</button>
+      </section>
+      <section class="log-entries"></section>
+    `;
+    container.querySelector('#log-add').addEventListener('click', () => {
+      const text = document.getElementById('log-note').value.trim();
+      if (!text) return;
+      State.addLessonLog({ mode: 'NOTE', note: text });
+      document.getElementById('log-note').value = '';
+      renderLog(State.getActiveClass());
+    });
+    container.querySelector('#log-export').addEventListener('click', () => {
+      const blob = new Blob([JSON.stringify(cls.lessonLog, null, 2)], { type: 'application/json' });
+      download(blob, `${cls.id}-lesson-log.json`);
+    });
+    const list = container.querySelector('.log-entries');
+    list.innerHTML = cls.lessonLog.slice().reverse().map((entry) => `
+      <article class="log-entry">
+        <header>${new Date(entry.timestamp || Date.now()).toLocaleString()} – ${entry.mode}</header>
+        <pre>${JSON.stringify(entry, null, 2)}</pre>
+      </article>
+    `).join('');
+  }
+
+  function renderSettings() {
+    const container = document.getElementById('view-SETTINGS');
+    const settings = State.store.settings;
+    container.innerHTML = `
+      <h2>Settings</h2>
+      <label>Change PIN <input id="settings-pin" type="password" value="${settings.pin}" maxlength="4"></label>
+      <label>Bonus Duration (seconds) <input id="settings-bonus" type="number" value="${settings.bonusDuration}"></label>
+      <label>Auto Bonus Minutes <input id="settings-auto" type="number" value="${settings.autoBonusMinutes}"></label>
+      <button id="settings-save" class="primary">Save Settings</button>
+    `;
+    container.querySelector('#settings-save').addEventListener('click', () => {
+      settings.pin = document.getElementById('settings-pin').value || State.DEFAULT_PIN;
+      settings.bonusDuration = Number(document.getElementById('settings-bonus').value) || 30;
+      settings.autoBonusMinutes = Number(document.getElementById('settings-auto').value) || 10;
+      State.persist();
+      alert('Settings saved');
+    });
+  }
+
+  function renderClassAdmin(cls) {
+    const container = document.getElementById('view-CLASS');
+    container.innerHTML = `
+      <h2>Class Administration (${cls.id})</h2>
+      <section>
+        <h3>Roster Import</h3>
+        <textarea id="class-roster" rows="4" placeholder="CSV: Group, Name"></textarea>
+        <button id="class-import" class="primary">Import Roster</button>
+      </section>
+      <section>
+        <h3>Schedule</h3>
+        <ul>${(cls.schedule || []).map((item) => `<li>${item}</li>`).join('')}</ul>
+        <input id="class-schedule" placeholder="e.g., Monday 09:00">
+        <button id="class-add-schedule" class="ghost">Add Time</button>
+      </section>
+      <section>
+        <h3>Attendance</h3>
+        <button id="class-start-session" class="primary">Start Session</button>
+      </section>
+    `;
+    container.querySelector('#class-import').addEventListener('click', () => importRoster(cls));
+    container.querySelector('#class-add-schedule').addEventListener('click', () => {
+      const value = document.getElementById('class-schedule').value;
+      if (!value) return;
+      cls.schedule.push(value);
+      State.persist();
+      renderClassAdmin(cls);
+    });
+    container.querySelector('#class-start-session').addEventListener('click', () => {
+      const now = new Date().toLocaleString();
+      State.addLessonLog({ mode: 'SESSION', startedAt: now });
+      alert('Session started!');
+    });
+  }
+
+  function importRoster(cls) {
+    const text = document.getElementById('class-roster').value.trim();
+    if (!text) return;
+    text.split(/\n/).forEach((line) => {
+      const [group, name] = line.split(',').map((part) => part.trim());
+      if (!group || !name) return;
+      if (!cls.roster.groups[group]) {
+        cls.roster.groups[group] = { name: `Group ${group}`, avatar: '😀', score: 0, behavior: 'Balanced' };
+      }
+      const list = cls.roster.groups[group].members || [];
+      list.push(name);
+      cls.roster.groups[group].members = list;
+    });
+    State.persist();
+    UI.renderGroups(document.getElementById('group-list'), cls);
+    alert('Roster imported');
+  }
+
+  function setupHomeActions() {
+    document.querySelectorAll('.home-card').forEach((card) => {
+      card.addEventListener('click', () => {
+        renderActiveTab(card.dataset.launch);
+        State.getActiveClass().current.mode = card.dataset.launch;
+        Sync.emit('mode-change', { mode: card.dataset.launch });
+      });
+    });
+  }
+
+  function setupBehaviorControls() {
+    document.getElementById('group-list').addEventListener('click', async (event) => {
+      const action = event.target.dataset.action;
+      if (!action) {
+        const card = event.target.closest('.group-card');
+        if (card) {
+          const cls = State.getActiveClass();
+          cls.current.activeGroup = card.dataset.group;
+          State.persist();
+          Sync.emit('group-change', { group: cls.current.activeGroup });
+        }
+        return;
+      }
+      const card = event.target.closest('.group-card');
+      const group = card.dataset.group;
+      if (['penalty', 'attendance'].includes(action)) {
+        const ok = await requirePin();
+        if (!ok) return;
+      }
+      const cls = State.getActiveClass();
+      if (action === 'attendance') {
+        const present = prompt('Mark attendance (comma separated)');
+        if (present) {
+          cls.attendanceHistory.push({ date: new Date().toISOString(), group, present: present.split(',').map((p) => p.trim()) });
+          State.persist();
+          alert('Attendance recorded');
+        }
+        return;
+      }
+      const value = action === 'positive' ? 5 : action === 'warning' ? 0 : -10;
+      State.recordBehavior(group, action, value);
+      UI.renderGroups(document.getElementById('group-list'), cls);
+      UI.renderProjectorHome(cls);
+      Sync.emit('behavior', { group, action, value });
+      if (action === 'penalty') {
+        cls.lastPenalty = Date.now();
+        scheduleAutoBonus(cls);
+      }
+    });
+  }
+
+  function setupPinDialog() {
+    const dialog = document.getElementById('pin-dialog');
+    if (dialog) {
+      dialog.setAttribute('role', 'dialog');
+    }
+  }
+
+  async function requirePin() {
+    const input = await UI.showPinDialog();
+    return input === State.store.settings.pin;
+  }
+
+  function openProjector() {
+    projectorWindow = window.open('projector.html', 'ozge-projector', 'width=1280,height=720');
+    Sync.emit('snapshot', buildSnapshot());
+  }
+
+  function buildSnapshot() {
+    const cls = State.getActiveClass();
+    return {
+      classId: cls.id,
+      mode: currentTab,
+      scores: cls.roster.groups,
+      unit: cls.current.unitId,
+      timerStart: cls.current.timerStart,
+      activeGroup: cls.current.activeGroup
+    };
+  }
+
+  function updateTimer() {
+    const cls = State.getActiveClass();
+    UI.renderTimer(cls);
+  }
+
+  function emergencyStop() {
+    State.store.projectorApproval = false;
+    State.store.blackout = true;
+    calmDown(120);
+    Sync.emit('emergency', {});
+  }
+
+  function calmDown(duration) {
+    if (calmOverlay) calmOverlay.remove();
+    calmOverlay = document.createElement('div');
+    calmOverlay.className = 'calm-overlay';
+    calmOverlay.innerHTML = '<p>Calm Down Mode</p><p>Take deep breaths…</p>';
+    document.body.appendChild(calmOverlay);
+    setTimeout(() => {
+      if (calmOverlay) calmOverlay.remove();
+      calmOverlay = null;
+    }, duration * 1000);
+  }
+
+  function scheduleAutoBonus(cls) {
+    if (autoBonusTimer) clearInterval(autoBonusTimer);
+    autoBonusTimer = setInterval(() => {
+      const minutes = State.store.settings.autoBonusMinutes;
+      const lastPenalty = cls.lastPenalty || 0;
+      if (Date.now() - lastPenalty > minutes * 60000) {
+        clearInterval(autoBonusTimer);
+        if (confirm('⭐ Team Spirit Bonus! Start bonus game?')) {
+          renderActiveTab('BONUS');
+        }
+      }
+    }, 60000);
+  }
+
+  function download(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function handleProjectorMessage(message) {
+    switch (message.type) {
+      case 'snapshot':
+        applySnapshot(message.payload);
+        break;
+      case 'score':
+        updateProjectorScores(message.payload);
+        break;
+      case 'mode-change':
+        showMode(message.payload.mode);
+        break;
+      case 'quiz-question':
+        displayQuizQuestion(message.payload);
+        break;
+      case 'behavior':
+        displayBehavior(message.payload);
+        break;
+      case 'draw-approval':
+        approveDrawing(message.payload);
+        break;
+      case 'group-change':
+        setActiveGroupDisplay(message.payload.group);
+        break;
+      case 'emergency':
+        blackout();
+        break;
+    }
+  }
+
+  function applySnapshot(snapshot) {
+    if (!snapshot) return;
+    document.querySelector('.projector-status [data-field="class"]').textContent = `Class ${snapshot.classId}`;
+    setActiveGroupDisplay(snapshot.activeGroup);
+    UI.renderProjectorHome(State.ensureClass(snapshot.classId));
+    showMode(snapshot.mode || 'HOME');
+  }
+
+  function setActiveGroupDisplay(group) {
+    const el = document.querySelector('.projector-status [data-field="group"]');
+    if (el) {
+      el.textContent = `Group ${group}`;
+    }
+  }
+
+  function updateProjectorScores(payload) {
+    const scores = document.getElementById('projector-scores');
+    if (!scores) return;
+    let span = scores.querySelector(`[data-group="${payload.group}"]`);
+    if (!span) {
+      span = document.createElement('span');
+      span.dataset.group = payload.group;
+      span.className = 'projector-score';
+      scores.appendChild(span);
+    }
+    span.textContent = `${payload.group}: ${payload.score}`;
+  }
+
+  function showMode(mode) {
+    if (mode && mode !== 'HOME') {
+      UI.setProjectorSection('projector-content');
+      document.querySelector('#projector-content [data-field="mode"]').textContent = mode;
+      const subtitle = document.querySelector('#projector-content [data-field="subtitle"]');
+      if (subtitle) {
+        subtitle.textContent = 'Stay focused!';
+      }
+      const body = document.getElementById('projector-content-body');
+      if (body) {
+        body.innerHTML = `<p class="projector-instruction">Stay focused! The teacher is guiding the <strong>${mode}</strong> activity.</p>`;
+      }
+    } else {
+      UI.setProjectorSection('projector-home');
+    }
+  }
+
+  function displayQuizQuestion(payload) {
+    const body = document.getElementById('projector-content-body');
+    if (!body) return;
+    if (payload && payload.classId) {
+      const active = State.getActiveClass();
+      if (active && active.id && active.id !== payload.classId) {
+        return;
+      }
+    }
+    if (!payload || !payload.question) {
+      const subtitle = document.querySelector('#projector-content [data-field="subtitle"]');
+      if (subtitle) {
+        subtitle.textContent = 'Quiz';
+      }
+      body.innerHTML = '<p class="projector-instruction">Quiz complete! Await further instructions.</p>';
+      return;
+    }
+    const { unitTitle, prompt, index, total } = payload.question;
+    UI.setProjectorSection('projector-content');
+    const modeHeader = document.querySelector('#projector-content [data-field="mode"]');
+    if (modeHeader) {
+      modeHeader.textContent = 'QUIZ';
+    }
+    const subtitle = document.querySelector('#projector-content [data-field="subtitle"]');
+    if (subtitle) {
+      subtitle.textContent = `Question ${index} of ${total}`;
+    }
+    body.innerHTML = `
+      <article class="projector-quiz-card">
+        <h3>${unitTitle}</h3>
+        <p>${prompt}</p>
+        <span class="projector-quiz-note">Listen for your teacher to reveal the answer.</span>
+      </article>
+    `;
+  }
+
+  function displayBehavior(payload) {
+    const banner = document.createElement('div');
+    banner.className = 'projector-banner';
+    banner.textContent = `${payload.group} ${payload.action === 'positive' ? '👍' : payload.action === 'penalty' ? '⚠️' : '⚠️'}`;
+    document.body.appendChild(banner);
+    setTimeout(() => banner.remove(), 3000);
+  }
+
+  function approveDrawing(payload) {
+    UI.setProjectorSection('projector-approval');
+    const body = document.querySelector('#projector-approval .projector-await');
+    body.innerHTML = `<img src="${payload.dataUrl}" alt="Approved drawing" style="max-width:90%;border-radius:20px;">`;
+  }
+
+  function blackout() {
+    UI.setProjectorSection('projector-blackout');
+  }
+
+  if (bodyRole === 'teacher') {
+    initTeacher();
+    State.ready.then(() => updateActiveClass(State.getActiveClass().id));
+  } else {
+    initProjector();
+  }
+})();

--- a/ozge/js/draw.js
+++ b/ozge/js/draw.js
@@ -1,0 +1,233 @@
+(function () {
+  let canvas, ctx, drawing = false;
+  let strokeColor = '#0f1a2a';
+  let strokeWidth = 4;
+  let history = [];
+  let redoStack = [];
+  let wordIndex = 0;
+  let words = [];
+
+  function render(container, cls) {
+    container.innerHTML = `
+      <header class="mode-header">
+        <div>
+          <h2>Draw &amp; Spell</h2>
+          <p>Sketch the word while students spell it aloud.</p>
+        </div>
+        <div class="draw-words">
+          <button id="draw-prev" aria-label="Previous word">Prev</button>
+          <span id="draw-current"></span>
+          <button id="draw-next" aria-label="Next word">Next</button>
+          <button id="draw-shuffle" class="ghost">Shuffle</button>
+        </div>
+      </header>
+      <section>
+        <div class="draw-toolbar" role="toolbar" aria-label="Drawing controls">
+          <div class="color-row">
+            ${['#0f1a2a', '#3c50ff', '#f58b4c', '#4ad66d', '#ffffff'].map((color) => `<button class="color-swatch" data-color="${color}" style="background:${color}"></button>`).join('')}
+          </div>
+          <select id="draw-size" aria-label="Brush size">
+            <option value="3">Fine</option>
+            <option value="6" selected>Medium</option>
+            <option value="10">Bold</option>
+          </select>
+          <button id="draw-undo">Undo</button>
+          <button id="draw-redo">Redo</button>
+          <button id="draw-clear" class="ghost">Clear</button>
+          <button id="draw-save" class="primary">Save Snapshot</button>
+          <button id="draw-approve" class="ghost">Approve to Projector</button>
+        </div>
+        <canvas id="draw-canvas" class="draw-canvas" aria-label="Drawing canvas"></canvas>
+      </section>
+      <section>
+        <h3>Gallery</h3>
+        <div id="draw-gallery" class="gallery-grid"></div>
+      </section>
+    `;
+
+    canvas = container.querySelector('#draw-canvas');
+    ctx = canvas.getContext('2d');
+    resizeCanvas();
+    window.addEventListener('resize', resizeCanvas);
+    setupDrawing();
+
+    container.querySelectorAll('.color-swatch').forEach((button) => {
+      button.addEventListener('click', () => {
+        strokeColor = button.dataset.color;
+        container.querySelectorAll('.color-swatch').forEach((b) => b.classList.toggle('active', b === button));
+      });
+    });
+    container.querySelector('#draw-size').addEventListener('change', (event) => {
+      strokeWidth = Number(event.target.value);
+    });
+    container.querySelector('#draw-undo').addEventListener('click', undo);
+    container.querySelector('#draw-redo').addEventListener('click', redo);
+    container.querySelector('#draw-clear').addEventListener('click', () => confirmAction(() => clearCanvas()));
+    container.querySelector('#draw-save').addEventListener('click', () => saveSnapshot(cls));
+    container.querySelector('#draw-approve').addEventListener('click', () => approveDisplay(cls));
+    container.querySelector('#draw-prev').addEventListener('click', () => changeWord(-1, cls));
+    container.querySelector('#draw-next').addEventListener('click', () => changeWord(1, cls));
+    container.querySelector('#draw-shuffle').addEventListener('click', () => shuffleWords(cls));
+
+    initWordList(cls);
+  }
+
+  function initWordList(cls) {
+    const selected = cls.unitSelections.DRAW;
+    const pool = [];
+    cls.units.forEach((unit) => {
+      if (!selected.length || selected.includes(unit.id)) {
+        unit.words.forEach((word) => pool.push(word.term));
+      }
+    });
+    words = pool.length ? pool : ['pencil', 'classroom', 'learn'];
+    wordIndex = 0;
+    updateCurrentWord();
+  }
+
+  function updateCurrentWord() {
+    const current = document.getElementById('draw-current');
+    if (current) {
+      current.textContent = words[wordIndex % words.length];
+    }
+  }
+
+  function changeWord(delta, cls) {
+    wordIndex = (wordIndex + delta + words.length) % words.length;
+    updateCurrentWord();
+    clearCanvas();
+  }
+
+  function shuffleWords(cls) {
+    words = shuffle(words);
+    wordIndex = 0;
+    updateCurrentWord();
+    clearCanvas();
+  }
+
+  function resizeCanvas() {
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * window.devicePixelRatio;
+    canvas.height = rect.height * window.devicePixelRatio;
+    ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.strokeStyle = strokeColor;
+    ctx.lineWidth = strokeWidth;
+  }
+
+  function setupDrawing() {
+    const start = (event) => {
+      drawing = true;
+      redoStack = [];
+      ctx.beginPath();
+      const { x, y } = position(event);
+      ctx.moveTo(x, y);
+      history.push(canvas.toDataURL());
+    };
+    const move = (event) => {
+      if (!drawing) return;
+      const { x, y } = position(event);
+      ctx.strokeStyle = strokeColor;
+      ctx.lineWidth = strokeWidth;
+      ctx.lineTo(x, y);
+      ctx.stroke();
+    };
+    const end = () => {
+      drawing = false;
+      ctx.closePath();
+    };
+    canvas.addEventListener('mousedown', start);
+    canvas.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', end);
+    canvas.addEventListener('touchstart', (event) => {
+      event.preventDefault();
+      start(event.touches[0]);
+    });
+    canvas.addEventListener('touchmove', (event) => {
+      event.preventDefault();
+      move(event.touches[0]);
+    });
+    canvas.addEventListener('touchend', end);
+  }
+
+  function position(event) {
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: (event.clientX - rect.left),
+      y: (event.clientY - rect.top)
+    };
+  }
+
+  function undo() {
+    if (!history.length) return;
+    const last = history.pop();
+    redoStack.push(canvas.toDataURL());
+    restoreFromDataUrl(last);
+  }
+
+  function redo() {
+    if (!redoStack.length) return;
+    const next = redoStack.pop();
+    history.push(canvas.toDataURL());
+    restoreFromDataUrl(next);
+  }
+
+  function restoreFromDataUrl(dataUrl) {
+    const img = new Image();
+    img.onload = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0);
+    };
+    img.src = dataUrl;
+  }
+
+  function clearCanvas() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    history = [];
+    redoStack = [];
+  }
+
+  function confirmAction(action) {
+    if (confirm('Are you sure?')) action();
+  }
+
+  function saveSnapshot(cls) {
+    const dataUrl = canvas.toDataURL('image/png');
+    const gallery = document.getElementById('draw-gallery');
+    const img = document.createElement('img');
+    img.src = dataUrl;
+    img.alt = `Drawing of ${words[wordIndex]}`;
+    gallery.appendChild(img);
+    State.addSnapshot({ type: 'draw', word: words[wordIndex], dataUrl });
+  }
+
+  async function approveDisplay(cls) {
+    const valid = await requirePin();
+    if (!valid) return;
+    Sync.emit('draw-approval', { classId: cls.id, dataUrl: canvas.toDataURL('image/png') });
+  }
+
+  async function requirePin() {
+    const input = await UI.showPinDialog();
+    const pin = State.store.settings.pin;
+    if (input === pin) return true;
+    alert('Incorrect PIN');
+    return false;
+  }
+
+  function shuffle(array) {
+    const arr = array.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  window.Draw = {
+    render,
+    shuffle
+  };
+})();

--- a/ozge/js/ocr.js
+++ b/ozge/js/ocr.js
@@ -1,0 +1,41 @@
+(function () {
+  async function extractTextFromPDF(file) {
+    const buffer = await file.arrayBuffer();
+    const textDecoder = new TextDecoder();
+    const hint = textDecoder.decode(buffer.slice(0, 4096));
+    const matches = hint.match(/[A-Za-z0-9 ,.;:'"\n\r-]{4,}/g) || [];
+    return matches.join(" ").replace(/\s+/g, " ").trim();
+  }
+
+  async function extractTextFromImage(file) {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    const bitmap = await createImageBitmap(file);
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    ctx.drawImage(bitmap, 0, 0);
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const pixels = imageData.data;
+    let contrast = 0;
+    for (let i = 0; i < pixels.length; i += 4) {
+      const avg = (pixels[i] + pixels[i + 1] + pixels[i + 2]) / 3;
+      contrast += avg > 128 ? 1 : -1;
+    }
+    if (Math.abs(contrast) < pixels.length / 1000) {
+      return "";
+    }
+    return "(Image text approximation unavailable offline)";
+  }
+
+  async function runOCR(file) {
+    const ext = (file.name.split('.').pop() || '').toLowerCase();
+    if (ext === "pdf") {
+      return extractTextFromPDF(file);
+    }
+    return extractTextFromImage(file);
+  }
+
+  window.OCR = {
+    run: runOCR
+  };
+})();

--- a/ozge/js/puzzle.js
+++ b/ozge/js/puzzle.js
@@ -1,0 +1,144 @@
+(function () {
+  let container = null;
+  let currentWord = null;
+
+  function render(view, cls) {
+    container = view;
+    if (!container) return;
+    container.innerHTML = `
+      <header class="mode-header">
+        <div>
+          <h2>Puzzle Tiles</h2>
+          <p>Drag the letters into place to spell the word.</p>
+        </div>
+        <button id="puzzle-new" class="primary">New Word</button>
+      </header>
+      <section class="puzzle-body">
+        <div class="puzzle-target" aria-live="polite"></div>
+        <div class="puzzle-tiles" aria-label="Letter tiles"></div>
+        <div class="puzzle-feedback" data-field="feedback"></div>
+      </section>
+    `;
+    container.querySelector('#puzzle-new').addEventListener('click', () => nextWord(cls));
+    nextWord(cls);
+  }
+
+  function nextWord(cls) {
+    const units = getWordPool(cls);
+    if (!units.length) {
+      container.querySelector('.puzzle-target').textContent = 'No words available.';
+      container.querySelector('.puzzle-tiles').innerHTML = '';
+      return;
+    }
+    const word = units[Math.floor(Math.random() * units.length)];
+    currentWord = word;
+    const target = container.querySelector('.puzzle-target');
+    target.innerHTML = '<span class="puzzle-slot" data-slot></span>'.repeat(word.length);
+    renderTiles(word.split(''));
+    container.querySelector('[data-field="feedback"]').textContent = '';
+  }
+
+  function renderTiles(letters) {
+    const area = container.querySelector('.puzzle-tiles');
+    area.innerHTML = '';
+    shuffle(letters).forEach((letter) => {
+      const tile = document.createElement('button');
+      tile.className = 'puzzle-tile';
+      tile.textContent = letter.toUpperCase();
+      tile.draggable = true;
+      tile.addEventListener('dragstart', (event) => {
+        event.dataTransfer.setData('text/plain', letter);
+      });
+      tile.addEventListener('click', () => placeLetter(letter));
+      area.appendChild(tile);
+    });
+    container.querySelectorAll('[data-slot]').forEach((slot, index) => {
+      slot.addEventListener('dragover', (event) => event.preventDefault());
+      slot.addEventListener('drop', (event) => {
+        event.preventDefault();
+        placeLetter(event.dataTransfer.getData('text/plain'), index);
+      });
+      slot.addEventListener('click', () => placeLetterPrompt(index));
+    });
+  }
+
+  function placeLetter(letter, index) {
+    const slots = Array.from(container.querySelectorAll('[data-slot]'));
+    if (typeof index !== 'number') {
+      index = slots.findIndex((slot) => !slot.textContent);
+    }
+    if (index < 0 || index >= slots.length) return;
+    const slot = slots[index];
+    if (slot.textContent) return;
+    slot.textContent = letter.toUpperCase();
+    validate();
+  }
+
+  function placeLetterPrompt(index) {
+    const letter = prompt('Type letter');
+    if (letter) {
+      placeLetter(letter[0], index);
+    }
+  }
+
+  function validate() {
+    const slots = Array.from(container.querySelectorAll('[data-slot]'));
+    const attempt = slots.map((slot) => slot.textContent.toLowerCase()).join('');
+    if (attempt.length !== currentWord.length) return;
+    const feedback = container.querySelector('[data-field="feedback"]');
+    if (attempt === currentWord) {
+      feedback.textContent = 'Great job! +5 points';
+      awardPoints(5);
+      confetti();
+    } else {
+      feedback.textContent = 'Try again!';
+    }
+  }
+
+  function awardPoints(points) {
+    const cls = State.getActiveClass();
+    const group = cls.current.activeGroup;
+    const g = cls.roster.groups[group];
+    if (g) {
+      g.score += points;
+      State.persist();
+      UI.renderGroups(document.getElementById('group-list'), cls);
+      Sync.emit('score', { classId: cls.id, group, score: g.score });
+    }
+  }
+
+  function confetti() {
+    const overlay = document.createElement('div');
+    overlay.className = 'confetti';
+    overlay.style.position = 'fixed';
+    overlay.style.inset = '0';
+    overlay.style.pointerEvents = 'none';
+    overlay.style.background = 'repeating-linear-gradient(90deg, rgba(255,255,255,0), rgba(255,255,255,0) 10px, rgba(79,109,245,0.4) 10px, rgba(79,109,245,0.4) 20px)';
+    document.body.appendChild(overlay);
+    setTimeout(() => overlay.remove(), 600);
+  }
+
+  function getWordPool(cls) {
+    const selected = cls.unitSelections.PUZZLE;
+    const words = [];
+    cls.units.forEach((unit) => {
+      if (!selected.length || selected.includes(unit.id)) {
+        unit.words.forEach((word) => words.push(word.term.toLowerCase()));
+      }
+    });
+    return words.filter((w) => w.length >= 3).slice(0, 50);
+  }
+
+  function shuffle(list) {
+    const arr = list.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  window.Puzzle = {
+    render
+  };
+})();

--- a/ozge/js/quiz.js
+++ b/ozge/js/quiz.js
@@ -1,0 +1,176 @@
+(function () {
+  let view = null;
+  let state = {
+    questions: [],
+    index: 0,
+    timer: null,
+    endTime: null,
+    selectedUnitIds: [],
+    correct: 0,
+    missedWords: []
+  };
+
+  function render(container, cls) {
+    view = container;
+    if (!view) return;
+    view.innerHTML = `
+      <header class="mode-header">
+        <div>
+          <h2>Quiz Mode</h2>
+          <p>Timed multiple-choice questions with instant feedback.</p>
+        </div>
+        <div class="status-pill">
+          <span>Progress</span>
+          <span data-field="progress">0 / 0</span>
+        </div>
+      </header>
+      <section class="quiz-body">
+        <div class="quiz-question" data-field="question">Select "Start Quiz" to begin.</div>
+        <div class="quiz-options" data-field="options"></div>
+        <div class="quiz-actions">
+          <button id="quiz-start" class="primary">Start Quiz</button>
+          <button id="quiz-skip" class="ghost">Skip</button>
+        </div>
+      </section>
+    `;
+    view.querySelector('#quiz-start').addEventListener('click', () => startQuiz(cls));
+    view.querySelector('#quiz-skip').addEventListener('click', () => nextQuestion(cls));
+    loadQuestions(cls);
+  }
+
+  function loadQuestions(cls) {
+    const selected = cls.unitSelections.QUIZ;
+    const units = cls.units.filter((unit) => !selected.length || selected.includes(unit.id));
+    const questions = [];
+    units.forEach((unit) => {
+      (unit.mcqs || []).forEach((mcq) => {
+        questions.push({ ...mcq, unitId: unit.id, unitTitle: unit.title });
+      });
+    });
+    state.questions = shuffle(questions).slice(0, 10);
+    state.index = 0;
+    updateProgress();
+  }
+
+  function startQuiz(cls) {
+    if (!state.questions.length) {
+      alert('No questions available. Add units in Content Manager.');
+      return;
+    }
+    state.index = 0;
+    state.endTime = Date.now() + 60000;
+    state.correct = 0;
+    state.missedWords = [];
+    renderQuestion(cls);
+    tickTimer(cls);
+  }
+
+  function renderQuestion(cls) {
+    const question = state.questions[state.index];
+    const questionEl = view.querySelector('[data-field="question"]');
+    const optionsEl = view.querySelector('[data-field="options"]');
+    if (!question) {
+      questionEl.textContent = 'Quiz complete!';
+      optionsEl.innerHTML = '';
+      emitProjectorQuestion(null, cls);
+      State.addLessonLog({
+        mode: 'QUIZ',
+        correct: state.correct,
+        total: state.questions.length,
+        unitId: cls.current.unitId,
+        missedWords: state.missedWords
+      });
+      return;
+    }
+    questionEl.textContent = `${question.unitTitle}: ${question.question}`;
+    optionsEl.innerHTML = '';
+    question.options.forEach((option, index) => {
+      const button = document.createElement('button');
+      button.textContent = option;
+      button.addEventListener('click', () => handleAnswer(cls, index));
+      optionsEl.appendChild(button);
+    });
+    emitProjectorQuestion({
+      unitTitle: question.unitTitle,
+      prompt: question.question,
+      index: state.index + 1,
+      total: state.questions.length
+    }, cls);
+    updateProgress();
+  }
+
+  function handleAnswer(cls, index) {
+    const question = state.questions[state.index];
+    if (!question) return;
+    const correct = index === question.answer;
+    if (correct) {
+      state.correct += 1;
+      awardPoints(cls.current.activeGroup, 10);
+    } else {
+      state.missedWords.push(question.options[question.answer]);
+    }
+    nextQuestion(cls);
+  }
+
+  function nextQuestion(cls) {
+    if (state.index < state.questions.length - 1) {
+      state.index += 1;
+      renderQuestion(cls);
+    } else {
+      state.index = state.questions.length;
+      renderQuestion(cls);
+    }
+  }
+
+  function awardPoints(group, points) {
+    const cls = State.getActiveClass();
+    const g = cls.roster.groups[group];
+    if (g) {
+      g.score += points;
+      State.persist();
+      UI.renderGroups(document.getElementById('group-list'), cls);
+      Sync.emit('score', { classId: cls.id, group, score: g.score });
+    }
+  }
+
+  function updateProgress() {
+    if (!view) return;
+    const display = view.querySelector('[data-field="progress"]');
+    if (display) {
+      display.textContent = `${Math.min(state.index + 1, state.questions.length)} / ${state.questions.length}`;
+    }
+  }
+
+  function tickTimer(cls) {
+    if (!state.endTime) return;
+    const remaining = Math.max(0, state.endTime - Date.now());
+    cls.current.timerStart = Date.now() - (60000 - remaining);
+    UI.renderTimer(cls);
+    if (remaining <= 0) {
+      state.endTime = null;
+      renderQuestion(cls);
+      return;
+    }
+    requestAnimationFrame(() => tickTimer(cls));
+  }
+
+  function shuffle(list) {
+    const arr = list.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function emitProjectorQuestion(payload, cls) {
+    Sync.emit('quiz-question', {
+      classId: cls.id,
+      question: payload
+    });
+  }
+
+  window.Quiz = {
+    render
+  };
+})();

--- a/ozge/js/speech.js
+++ b/ozge/js/speech.js
@@ -1,0 +1,54 @@
+(function () {
+  let recognition = null;
+  let available = false;
+
+  function init() {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (SpeechRecognition) {
+      recognition = new SpeechRecognition();
+      recognition.lang = "en-US";
+      recognition.continuous = false;
+      recognition.interimResults = false;
+      available = true;
+    }
+  }
+
+  function startListening(onResult, onError) {
+    if (!available) {
+      setTimeout(() => onResult({ transcript: "", score: simulateScore() }), 500);
+      return () => {};
+    }
+    recognition.start();
+    recognition.onresult = (event) => {
+      const transcript = Array.from(event.results)
+        .map((result) => result[0])
+        .map((result) => result.transcript)
+        .join(" ");
+      onResult({ transcript, score: evaluateTranscript(transcript) });
+    };
+    recognition.onerror = (event) => {
+      onError(event.error);
+    };
+    return () => recognition.stop();
+  }
+
+  function evaluateTranscript(transcript) {
+    const words = transcript.trim().split(/\s+/).filter(Boolean);
+    if (!words.length) return 40;
+    const averageLength = words.reduce((acc, w) => acc + w.length, 0) / words.length;
+    const clarity = Math.min(1, words.length / 10);
+    const score = Math.round(50 + clarity * 30 + Math.min(10, averageLength * 2));
+    return Math.min(100, Math.max(0, score));
+  }
+
+  function simulateScore() {
+    return 60 + Math.round(Math.random() * 40);
+  }
+
+  init();
+
+  window.Speaking = {
+    startListening,
+    available: () => available
+  };
+})();

--- a/ozge/js/state.js
+++ b/ozge/js/state.js
@@ -1,0 +1,248 @@
+(function () {
+  const CLASSES = ["5A", "5B", "5C", "5D"];
+  const DEFAULT_PIN = "1234";
+  const STORAGE_KEY = "ozge-state-v1";
+
+  const baseState = {
+    activeClass: "5A",
+    projectorApproval: false,
+    blackout: false,
+    calmModeUntil: null,
+    settings: {
+      pin: DEFAULT_PIN,
+      bonusDuration: 30,
+      autoBonusMinutes: 10
+    }
+  };
+
+  let store = null;
+
+  function createEmptyClassState(id) {
+    const groups = ["A", "B", "C", "D", "E", "F", "G", "H"].reduce((acc, label) => {
+      acc[label] = {
+        name: `Group ${label}`,
+        avatar: "😀",
+        score: 0,
+        behavior: "Balanced",
+        badges: [],
+        penalties: 0,
+        attendance: {}
+      };
+      return acc;
+    }, {});
+
+    return {
+      id,
+      units: [],
+      roster: { groups },
+      schedule: [],
+      attendanceHistory: [],
+      unitSelections: {
+        QUIZ: [],
+        PUZZLE: [],
+        SPEAK: [],
+        STORY: [],
+        DRAW: []
+      },
+      behaviorLog: [],
+      lessonLog: [],
+      sessionSnapshots: [],
+      contentPacks: [],
+      approvals: {
+        pending: false,
+        snapshot: null
+      },
+      current: {
+        mode: "SPLASH",
+        unitId: null,
+        timerStart: null,
+        activeGroup: "A",
+        streak: 0
+      },
+      weekly: {
+        analytics: [],
+        lastUpdated: null
+      }
+    };
+  }
+
+  function loadSavedState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") return null;
+      return parsed;
+    } catch (err) {
+      console.warn("State restore failed", err);
+      return null;
+    }
+  }
+
+  function persist() {
+    if (!store) return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  }
+
+  async function loadDemoData() {
+    const [unitsRes, rosterRes] = await Promise.all([
+      fetch("data/demo-units.json").then((r) => r.json()),
+      fetch("data/demo-rosters.json").then((r) => r.json())
+    ]);
+    CLASSES.forEach((id) => {
+      if (!store.classes[id]) {
+        store.classes[id] = createEmptyClassState(id);
+      }
+      const classState = store.classes[id];
+      const roster = rosterRes[id];
+      if (roster) {
+        Object.entries(roster.groups || {}).forEach(([group, names]) => {
+          if (classState.roster.groups[group]) {
+            classState.roster.groups[group].members = names;
+          }
+        });
+        classState.schedule = roster.schedule || [];
+      }
+      const demoUnits = unitsRes[id] || [];
+      if (!classState.units.length) {
+        classState.units = demoUnits;
+      }
+    });
+  }
+
+  function initStore() {
+    const saved = loadSavedState();
+    if (saved) {
+      store = saved;
+      CLASSES.forEach((id) => {
+        if (!store.classes[id]) {
+          store.classes[id] = createEmptyClassState(id);
+        }
+      });
+    } else {
+      store = {
+        ...baseState,
+        classes: {}
+      };
+      CLASSES.forEach((id) => {
+        store.classes[id] = createEmptyClassState(id);
+      });
+    }
+  }
+
+  function ensureClass(id) {
+    if (!store.classes[id]) {
+      store.classes[id] = createEmptyClassState(id);
+    }
+    return store.classes[id];
+  }
+
+  function getActiveClass() {
+    return ensureClass(store.activeClass);
+  }
+
+  function update(fn) {
+    const result = fn(store, getActiveClass());
+    persist();
+    return result;
+  }
+
+  function setActiveClass(id) {
+    if (!CLASSES.includes(id)) return;
+    store.activeClass = id;
+    persist();
+    window.dispatchEvent(new CustomEvent("ozge:class-change", { detail: { id } }));
+  }
+
+  function recordBehavior(group, action, value) {
+    const cls = getActiveClass();
+    const entry = {
+      timestamp: Date.now(),
+      group,
+      action,
+      value
+    };
+    cls.behaviorLog.push(entry);
+    const g = cls.roster.groups[group];
+    if (g) {
+      if (action === "positive") {
+        g.score += value;
+        g.behavior = "Excellent";
+      } else if (action === "warning") {
+        g.behavior = "Warning";
+      } else if (action === "penalty") {
+        g.score = Math.max(0, g.score - Math.abs(value));
+        g.behavior = "Penalty";
+        g.penalties += 1;
+      }
+    }
+    persist();
+    return entry;
+  }
+
+  function addLessonLog(entry) {
+    const cls = getActiveClass();
+    cls.lessonLog.push({ ...entry, timestamp: Date.now() });
+    persist();
+  }
+
+  function addSnapshot(snapshot) {
+    const cls = getActiveClass();
+    cls.sessionSnapshots.push({ ...snapshot, timestamp: Date.now(), id: crypto.randomUUID() });
+    persist();
+  }
+
+  function upsertUnit(unit) {
+    const cls = getActiveClass();
+    const index = cls.units.findIndex((u) => u.id === unit.id);
+    if (index >= 0) {
+      cls.units[index] = unit;
+    } else {
+      cls.units.push(unit);
+    }
+    persist();
+  }
+
+  function setUnitSelection(mode, ids) {
+    const cls = getActiveClass();
+    cls.unitSelections[mode] = Array.from(new Set(ids));
+    persist();
+  }
+
+  function resetScores() {
+    const cls = getActiveClass();
+    Object.values(cls.roster.groups).forEach((group) => {
+      group.score = 0;
+      group.behavior = "Balanced";
+      group.penalties = 0;
+    });
+    persist();
+  }
+
+  initStore();
+
+  const ready = loadDemoData().then(() => {
+    persist();
+    return store;
+  });
+
+  window.State = {
+    ready,
+    CLASSES,
+    get store() {
+      return store;
+    },
+    getActiveClass,
+    setActiveClass,
+    update,
+    recordBehavior,
+    addLessonLog,
+    addSnapshot,
+    upsertUnit,
+    setUnitSelection,
+    resetScores,
+    persist,
+    ensureClass,
+    DEFAULT_PIN
+  };
+})();

--- a/ozge/js/storage.js
+++ b/ozge/js/storage.js
@@ -1,0 +1,117 @@
+(function () {
+  if (!('indexedDB' in window)) {
+    window.ContentDB = {
+      async listFiles() {
+        return [];
+      },
+      async getFile() {
+        return null;
+      },
+      async deleteFile() {},
+      async storeImportedFile() {
+        throw new Error('IndexedDB not supported');
+      }
+    };
+    return;
+  }
+
+  const DB_NAME = 'ozge-content-store';
+  const DB_VERSION = 1;
+  const STORE_FILES = 'files';
+  let dbPromise = null;
+
+  function openDb() {
+    if (dbPromise) return dbPromise;
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE_FILES)) {
+          const store = db.createObjectStore(STORE_FILES, { keyPath: 'id' });
+          store.createIndex('classId', 'classId', { unique: false });
+          store.createIndex('addedAt', 'addedAt', { unique: false });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    return dbPromise;
+  }
+
+  async function withStore(mode, handler) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_FILES, mode);
+      const store = tx.objectStore(STORE_FILES);
+      handler(store, tx);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async function saveFile(record) {
+    await withStore('readwrite', (store) => {
+      store.put(record);
+    });
+    return record.id;
+  }
+
+  async function listFiles(classId) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_FILES, 'readonly');
+      const store = tx.objectStore(STORE_FILES);
+      const index = store.index('classId');
+      const request = index.getAll(IDBKeyRange.only(classId));
+      request.onsuccess = () => {
+        const files = (request.result || []).sort((a, b) => {
+          return new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime();
+        });
+        resolve(files);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async function deleteFile(id) {
+    await withStore('readwrite', (store) => {
+      store.delete(id);
+    });
+  }
+
+  async function getFile(id) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_FILES, 'readonly');
+      const store = tx.objectStore(STORE_FILES);
+      const request = store.get(id);
+      request.onsuccess = () => resolve(request.result || null);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async function storeImportedFile(classId, file, extras = {}) {
+    const buffer = await file.arrayBuffer();
+    const blob = new Blob([buffer], { type: file.type || 'application/octet-stream' });
+    const id = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `file-${Date.now()}-${Math.random()}`;
+    const record = {
+      id,
+      classId,
+      name: file.name,
+      type: file.type || 'application/octet-stream',
+      size: file.size,
+      addedAt: new Date().toISOString(),
+      blob,
+      ...extras
+    };
+    await saveFile(record);
+    return record.id;
+  }
+
+  window.ContentDB = {
+    listFiles,
+    getFile,
+    deleteFile,
+    storeImportedFile
+  };
+})();

--- a/ozge/js/story.js
+++ b/ozge/js/story.js
@@ -1,0 +1,102 @@
+(function () {
+  let containerRef = null;
+
+  function render(container, cls) {
+    containerRef = container;
+    container.innerHTML = `
+      <header class="mode-header">
+        <div>
+          <h2>Story Panels</h2>
+          <p>Use the mini comic prompts for reading and comprehension.</p>
+        </div>
+        <button id="story-new" class="primary">New Story</button>
+      </header>
+      <section class="story-body">
+        <div class="story-panels" aria-live="polite"></div>
+        <div class="story-question"></div>
+        <div class="story-options"></div>
+      </section>
+    `;
+    container.querySelector('#story-new').addEventListener('click', () => loadStory(cls));
+    loadStory(cls);
+  }
+
+  function loadStory(cls) {
+    const pool = buildStoryPool(cls);
+    const story = pool[Math.floor(Math.random() * pool.length)];
+    const panels = containerRef.querySelector('.story-panels');
+    const questionEl = containerRef.querySelector('.story-question');
+    const optionsEl = containerRef.querySelector('.story-options');
+    panels.innerHTML = story.panels.map((text, index) => `<article class="story-panel"><span>${index + 1}</span><p>${text}</p></article>`).join('');
+    questionEl.textContent = story.question;
+    optionsEl.innerHTML = '';
+    story.options.forEach((option, index) => {
+      const button = document.createElement('button');
+      button.textContent = option;
+      button.addEventListener('click', () => {
+        const correct = index === story.answer;
+        if (correct) {
+          awardPoints(cls, 8);
+        }
+        alert(correct ? 'Correct! +8 points' : 'Try again next time.');
+      });
+      optionsEl.appendChild(button);
+    });
+  }
+
+  function buildStoryPool(cls) {
+    const selected = cls.unitSelections.STORY;
+    const units = cls.units.filter((unit) => !selected.length || selected.includes(unit.id));
+    if (!units.length) {
+      return [
+        {
+          panels: ['The classroom is quiet.', 'The teacher writes on the board.', 'Students raise their hands.'],
+          question: 'What are the students doing?',
+          options: ['Sleeping', 'Raising their hands', 'Leaving'],
+          answer: 1
+        }
+      ];
+    }
+    return units.map((unit) => {
+      const words = unit.words.slice(0, 4).map((w) => w.term);
+      if (!words.length) {
+        words.push('classroom');
+      }
+      const options = shuffle(words);
+      return {
+        panels: [
+          `${unit.title} begins with a warm-up activity.`,
+          `Students practice words like ${words.join(', ')}.`,
+          `Everyone shares a sentence using the new words.`
+        ],
+        question: `What is one of the focus words in ${unit.title}?`,
+        options,
+        answer: Math.max(0, options.indexOf(words[0]))
+      };
+    });
+  }
+
+  function awardPoints(cls, points) {
+    const group = cls.current.activeGroup;
+    const g = cls.roster.groups[group];
+    if (g) {
+      g.score += points;
+      State.persist();
+      UI.renderGroups(document.getElementById('group-list'), cls);
+      Sync.emit('score', { classId: cls.id, group, score: g.score });
+    }
+  }
+
+  function shuffle(list) {
+    const arr = list.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  window.Story = {
+    render
+  };
+})();

--- a/ozge/js/sync.js
+++ b/ozge/js/sync.js
@@ -1,0 +1,80 @@
+(function () {
+  const CHANNEL_NAME = "ozge-sync";
+  const SNAPSHOT_KEY = "ozge-sync-snapshot";
+  const listeners = new Set();
+  let channel = null;
+  let lastLocalEmit = 0;
+
+  function initChannel() {
+    try {
+      channel = new BroadcastChannel(CHANNEL_NAME);
+      channel.onmessage = (event) => {
+        if (!event || !event.data) return;
+        dispatch(event.data);
+      };
+    } catch (err) {
+      console.warn("BroadcastChannel unavailable", err);
+    }
+  }
+
+  function dispatch(message) {
+    listeners.forEach((handler) => {
+      try {
+        handler(message);
+      } catch (err) {
+        console.error("Sync handler error", err);
+      }
+    });
+  }
+
+  function emit(type, payload) {
+    const message = { type, payload, timestamp: Date.now() };
+    lastLocalEmit = message.timestamp;
+    if (channel) {
+      channel.postMessage(message);
+    }
+    localStorage.setItem("ozge-sync-last", JSON.stringify(message));
+    dispatch(message);
+  }
+
+  function pollFallback() {
+    window.addEventListener("storage", (event) => {
+      if (event.key !== "ozge-sync-last" || !event.newValue) return;
+      try {
+        const parsed = JSON.parse(event.newValue);
+        if (parsed.timestamp <= lastLocalEmit) return;
+        dispatch(parsed);
+      } catch (err) {
+        console.warn("Sync fallback parse error", err);
+      }
+    });
+  }
+
+  function saveSnapshot(state) {
+    localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(state));
+  }
+
+  function loadSnapshot() {
+    try {
+      const raw = localStorage.getItem(SNAPSHOT_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch (err) {
+      console.warn("Snapshot load failed", err);
+      return null;
+    }
+  }
+
+  initChannel();
+  pollFallback();
+
+  window.Sync = {
+    on(handler) {
+      listeners.add(handler);
+      return () => listeners.delete(handler);
+    },
+    emit,
+    saveSnapshot,
+    loadSnapshot,
+    CHANNEL_NAME
+  };
+})();

--- a/ozge/js/ui.js
+++ b/ozge/js/ui.js
@@ -1,0 +1,171 @@
+(function () {
+  const teacherViews = {};
+  const projectorViews = {};
+
+  function $(selector, root = document) {
+    return root.querySelector(selector);
+  }
+
+  function $all(selector, root = document) {
+    return Array.from(root.querySelectorAll(selector));
+  }
+
+  function formatTimer(ms) {
+    if (!ms) return "00:00";
+    const total = Math.max(0, Math.floor(ms / 1000));
+    const m = String(Math.floor(total / 60)).padStart(2, "0");
+    const s = String(total % 60).padStart(2, "0");
+    return `${m}:${s}`;
+  }
+
+  function getGroupList(cls) {
+    return Object.entries(cls.roster.groups);
+  }
+
+  function renderGroups(container, cls) {
+    if (!container) return;
+    container.innerHTML = "";
+    const template = document.getElementById("group-card-template");
+    getGroupList(cls).forEach(([id, data]) => {
+      const node = template.content.firstElementChild.cloneNode(true);
+      node.dataset.group = id;
+      node.querySelector('[data-field="name"]').textContent = `${data.name}`;
+      node.querySelector('[data-field="score"]').textContent = data.score;
+      node.querySelector('[data-field="behavior"]').textContent = data.behavior;
+      node.querySelector('.avatar').textContent = data.avatar || "😀";
+      container.appendChild(node);
+    });
+  }
+
+  function renderHome(cls) {
+    const topicEl = document.querySelector('[data-bind="topic"]');
+    if (topicEl) {
+      const unit = cls.units.find((u) => u.id === cls.current.unitId) || cls.units[0];
+      topicEl.textContent = unit ? unit.title : "—";
+    }
+    renderGroups(document.getElementById("group-list"), cls);
+  }
+
+  function renderProjectorHome(cls) {
+    const avatars = document.getElementById("projector-avatars");
+    const scores = document.getElementById("projector-scores");
+    if (avatars) {
+      avatars.innerHTML = "";
+      getGroupList(cls).forEach(([id, data]) => {
+        const span = document.createElement("span");
+        span.className = "projector-avatar";
+        span.dataset.group = id;
+        span.textContent = `${data.avatar || "😀"} ${id}`;
+        avatars.appendChild(span);
+      });
+    }
+    if (scores) {
+      scores.innerHTML = "";
+      getGroupList(cls).forEach(([id, data]) => {
+        const span = document.createElement("span");
+        span.className = "projector-score";
+        span.dataset.group = id;
+        span.textContent = `${id}: ${data.score}`;
+        scores.appendChild(span);
+      });
+    }
+  }
+
+  function setActiveTab(tabId) {
+    $all('#teacher-tabs .tab').forEach((btn) => {
+      btn.classList.toggle("active", btn.dataset.tab === tabId);
+    });
+    $all('#view-container .view').forEach((view) => {
+      view.classList.toggle("view-active", view.id === `view-${tabId}`);
+    });
+  }
+
+  function toggleHeader(active) {
+    const header = document.getElementById("main-header");
+    const main = document.getElementById("main");
+    if (!header || !main) return;
+    header.classList.toggle("hidden", !active);
+    main.classList.toggle("hidden", !active);
+  }
+
+  function showPinDialog() {
+    const dialog = document.getElementById("pin-dialog");
+    const input = document.getElementById("pin-input");
+    if (!dialog || !input) return new Promise((resolve) => resolve(false));
+    dialog.hidden = false;
+    input.value = "";
+    input.focus();
+    return new Promise((resolve) => {
+      function cleanup(result) {
+        dialog.hidden = true;
+        input.value = "";
+        cancelBtn.removeEventListener("click", onCancel);
+        confirmBtn.removeEventListener("click", onConfirm);
+        dialog.removeEventListener("keydown", onKey);
+        resolve(result);
+      }
+      function onCancel() {
+        cleanup(false);
+      }
+      function onConfirm() {
+        cleanup(input.value);
+      }
+      function onKey(event) {
+        if (event.key === "Escape") {
+          cleanup(false);
+        } else if (event.key === "Enter") {
+          cleanup(input.value);
+        }
+      }
+      const cancelBtn = document.getElementById("pin-cancel");
+      const confirmBtn = document.getElementById("pin-confirm");
+      cancelBtn.addEventListener("click", onCancel);
+      confirmBtn.addEventListener("click", onConfirm);
+      dialog.addEventListener("keydown", onKey);
+    });
+  }
+
+  function setProjectorSection(section) {
+    const sections = $all('.projector-section');
+    sections.forEach((node) => {
+      node.classList.toggle("active", node.id === section);
+    });
+  }
+
+  function setProjectorStatus(cls) {
+    const header = document.querySelector('.projector-status');
+    if (!header) return;
+    const mode = cls.current.mode;
+    const unit = cls.units.find((u) => u.id === cls.current.unitId) || { title: "—" };
+    header.querySelector('[data-field="class"]').textContent = `Class ${cls.id}`;
+    header.querySelector('[data-field="unit"]').textContent = unit.title;
+    header.querySelector('[data-field="timer"]').textContent = formatTimer(Date.now() - (cls.current.timerStart || Date.now()));
+    header.querySelector('[data-field="group"]').textContent = `Group ${cls.current.activeGroup}`;
+    const modeHeader = document.querySelector('#projector-content [data-field="mode"]');
+    if (modeHeader) {
+      modeHeader.textContent = mode;
+    }
+  }
+
+  function renderTimer(cls) {
+    const timerEl = document.querySelector('[data-bind="timer"]');
+    if (timerEl) {
+      timerEl.textContent = formatTimer(Date.now() - (cls.current.timerStart || Date.now()));
+    }
+    if (document.body.dataset.role === "projector") {
+      setProjectorStatus(cls);
+    }
+  }
+
+  window.UI = {
+    renderHome,
+    renderGroups,
+    renderProjectorHome,
+    setActiveTab,
+    toggleHeader,
+    showPinDialog,
+    setProjectorSection,
+    setProjectorStatus,
+    renderTimer
+  };
+})();

--- a/ozge/package.json
+++ b/ozge/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ozge-classroom",
+  "version": "1.0.0",
+  "description": "Offline classroom dashboard for Özge – Classroom Edition",
+  "main": "exe/main.js",
+  "private": true,
+  "scripts": {
+    "start": "electron .",
+    "package:win": "electron-packager . \"Ozge Classroom\" --platform=win32 --arch=x64 --out=dist --overwrite --app-version=1.0.0 --prune=true --ignore=\"dist\"",
+    "package:linux": "electron-packager . \"Ozge Classroom\" --platform=linux --arch=x64 --out=dist --overwrite --app-version=1.0.0 --prune=true --ignore=\"dist\""
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-packager": "^17.1.2"
+  }
+}

--- a/ozge/projector.html
+++ b/ozge/projector.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Özge – Classroom Edition • Projector View</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body data-role="projector">
+  <header class="projector-header">
+    <div class="projector-title">
+      <svg aria-hidden="true"><use href="assets/icons.svg#logo"></use></svg>
+      <h1>Özge – Projector View</h1>
+    </div>
+    <div class="projector-status">
+      <span data-field="class">Class —</span>
+      <span data-field="unit">Unit —</span>
+      <span data-field="timer">00:00</span>
+      <span data-field="group">Group —</span>
+    </div>
+  </header>
+
+  <main id="projector-main" aria-live="polite">
+    <section id="projector-home" class="projector-section active">
+      <div class="projector-cards">
+        <article class="projector-card" data-mode="QUIZ">
+          <h2>Vocabulary Challenge</h2>
+          <p>Sharpen your word power!</p>
+        </article>
+        <article class="projector-card" data-mode="PUZZLE">
+          <h2>Grammar Puzzle</h2>
+          <p>Arrange the tiles to reveal the sentence.</p>
+        </article>
+        <article class="projector-card" data-mode="SPEAK">
+          <h2>Speaking Spotlight</h2>
+          <p>Say it loud and proud.</p>
+        </article>
+        <article class="projector-card" data-mode="STORY">
+          <h2>Story Panel</h2>
+          <p>Read and respond.</p>
+        </article>
+        <article class="projector-card" data-mode="DRAW">
+          <h2>Draw &amp; Spell</h2>
+          <p>Sketch the word while spelling aloud.</p>
+        </article>
+        <article class="projector-card" data-mode="BONUS">
+          <h2>Bonus Blitz</h2>
+          <p>Double points in 30 seconds!</p>
+        </article>
+      </div>
+    </section>
+    <section id="projector-content" class="projector-section">
+      <header class="projector-mode-header">
+        <h2 data-field="mode">Mode</h2>
+        <p data-field="subtitle">Stay focused!</p>
+      </header>
+      <div id="projector-content-body"></div>
+    </section>
+    <section id="projector-approval" class="projector-section">
+      <div class="projector-await">
+        <svg aria-hidden="true"><use href="assets/icons.svg#hourglass"></use></svg>
+        <h2>Awaiting teacher approval…</h2>
+      </div>
+    </section>
+    <section id="projector-blackout" class="projector-section">
+      <div class="projector-blackout-message">
+        <h2>Screen temporarily hidden</h2>
+        <p>Please wait for the teacher.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="projector-footer">
+    <div class="avatars" id="projector-avatars"></div>
+    <div class="scores" id="projector-scores"></div>
+  </footer>
+
+  <script src="js/state.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/ui.js"></script>
+  <script src="js/storage.js"></script>
+  <script src="js/ocr.js"></script>
+  <script src="js/content.js"></script>
+  <script src="js/speech.js"></script>
+  <script src="js/analytics.js"></script>
+  <script src="js/quiz.js"></script>
+  <script src="js/puzzle.js"></script>
+  <script src="js/story.js"></script>
+  <script src="js/draw.js"></script>
+  <script src="js/bonus.js"></script>
+  <script src="js/core.js"></script>
+</body>
+</html>

--- a/ozge/scripts/build_exe.sh
+++ b/ozge/scripts/build_exe.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required to package the desktop build." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+if [ ! -d node_modules ]; then
+  npm install
+fi
+
+TARGET=${1:-win}
+case "$TARGET" in
+  win)
+    npm run package:win
+    ;;
+  linux)
+    npm run package:linux
+    ;;
+  *)
+    echo "Unknown target '$TARGET'. Use 'win' or 'linux'." >&2
+    exit 1
+    ;;
+esac
+

--- a/ozge/scripts/prepare_and_push.sh
+++ b/ozge/scripts/prepare_and_push.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+: "${GH_USERNAME?Need GH_USERNAME}"
+: "${GH_EMAIL?Need GH_EMAIL}"
+: "${GH_TOKEN?Need GH_TOKEN}"
+: "${GH_REPO?Need GH_REPO}"
+
+REMOTE_URL="https://${GH_TOKEN}@${GH_REPO#https://}"
+
+if [ ! -d .git ]; then
+  git init
+fi
+
+git config user.name "$GH_USERNAME"
+git config user.email "$GH_EMAIL"
+
+git checkout -B main
+
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to commit on main"
+else
+  git commit -m "feat: initial Özge app build"
+fi
+
+if git remote | grep -q '^origin$'; then
+  git remote set-url origin "$REMOTE_URL"
+else
+  git remote add origin "$REMOTE_URL"
+fi
+
+git push --set-upstream origin main
+
+# Deploy ozge/ contents to gh-pages
+WORKTREE_DIR="$(mktemp -d)"
+cleanup() {
+  git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
+  rm -rf "$WORKTREE_DIR"
+}
+trap cleanup EXIT
+
+if git ls-remote --heads origin gh-pages >/dev/null 2>&1 && git ls-remote --heads origin gh-pages | grep -q gh-pages; then
+  git worktree add "$WORKTREE_DIR" gh-pages
+else
+  git worktree add -B gh-pages "$WORKTREE_DIR"
+fi
+
+rsync -av --delete ozge/ "$WORKTREE_DIR"/ --exclude .git >/dev/null
+cd "$WORKTREE_DIR"
+
+git config user.name "$GH_USERNAME"
+git config user.email "$GH_EMAIL"
+
+git add -A
+if git diff --cached --quiet; then
+  echo "gh-pages is up to date"
+else
+  git commit -m "chore: update gh-pages"
+  git push origin gh-pages
+fi


### PR DESCRIPTION
## Summary
- broadcast quiz prompts to the projector view while keeping answer buttons on the teacher dashboard, including a dedicated projector layout
- persist imported PDFs and images in per-class IndexedDB storage with a Stored Files panel for download and cleanup
- add Electron packaging with helper scripts so the offline site can be bundled as a Windows/Linux executable

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e43014fe1c8328823b34a3de64442e