### PR TITLE
Add initial Ozge2 WPF scaffold with data and dual window host

### DIFF
--- a/Ozge.App/App.xaml
+++ b/Ozge.App/App.xaml
@@ -1,0 +1,12 @@
+<Application x:Class="Ozge.App.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="Views/TeacherDashboardWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/Ozge.App/App.xaml.cs
+++ b/Ozge.App/App.xaml.cs
@@ -1,0 +1,82 @@
+using System.Windows;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using Ozge.App.Host;
+using Ozge.App.Services;
+using Ozge.App.ViewModels;
+using Ozge.App.Views;
+using Ozge.Core.Services;
+using Ozge.Data.Extensions;
+using Ozge.Data.Services;
+using Ozge.Ocr.Services;
+
+namespace Ozge.App;
+
+public partial class App : Application
+{
+    private IHost? _host;
+
+    protected override async void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        var builder = Host.CreateDefaultBuilder(e.Args)
+            .ConfigureAppConfiguration(config =>
+            {
+                config.AddJsonFile("appsettings.json", optional: true);
+            })
+            .UseSerilog((context, cfg) =>
+            {
+                var logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Ozge2", "Logs");
+                Directory.CreateDirectory(logDirectory);
+                cfg.MinimumLevel.Debug();
+                cfg.WriteTo.File(Path.Combine(logDirectory, "ozge2-.log"), rollingInterval: RollingInterval.Day, restrictedToMinimumLevel: LogEventLevel.Information);
+            })
+            .ConfigureServices((context, services) =>
+            {
+                services.AddOzgeSqlite(context.Configuration);
+                services.AddSingleton<IDatabaseInitializer, DatabaseInitializer>();
+                services.AddSingleton<IAppStateStore, ImmutableAppStateStore>();
+                services.AddSingleton<IScreenSelectionService, ScreenSelectionService>();
+                services.AddSingleton<ProjectorActivationService>();
+                services.AddSingleton<IContentParser, OfflineContentParser>();
+
+                services.AddTransient<TeacherDashboardViewModel>();
+                services.AddTransient<ProjectorViewModel>();
+                services.AddTransient<TeacherDashboardWindow>();
+                services.AddTransient<ProjectorWindow>();
+            });
+
+        _host = builder.Build();
+        await _host.StartAsync();
+
+        var initializer = _host.Services.GetRequiredService<IDatabaseInitializer>();
+        await initializer.InitializeAsync();
+
+        var screenService = _host.Services.GetRequiredService<IScreenSelectionService>();
+        await screenService.InitializeAsync();
+
+        var stateStore = _host.Services.GetRequiredService<IAppStateStore>();
+        await stateStore.InitializeAsync();
+
+        var mainWindow = _host.Services.GetRequiredService<TeacherDashboardWindow>();
+        mainWindow.DataContext = _host.Services.GetRequiredService<TeacherDashboardViewModel>();
+        mainWindow.Show();
+
+        var projector = _host.Services.GetRequiredService<ProjectorActivationService>();
+        projector.TryShowProjectorWindow();
+    }
+
+    protected override async void OnExit(ExitEventArgs e)
+    {
+        if (_host is not null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        base.OnExit(e);
+    }
+}

--- a/Ozge.App/Host/ProjectorActivationService.cs
+++ b/Ozge.App/Host/ProjectorActivationService.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using Ozge.App.ViewModels;
+using Ozge.App.Views;
+using Ozge.Core.Services;
+
+namespace Ozge.App.Host;
+
+public class ProjectorActivationService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IScreenSelectionService _screenSelectionService;
+    private ProjectorWindow? _window;
+
+    public ProjectorActivationService(IServiceProvider serviceProvider, IScreenSelectionService screenSelectionService)
+    {
+        _serviceProvider = serviceProvider;
+        _screenSelectionService = screenSelectionService;
+    }
+
+    public void TryShowProjectorWindow()
+    {
+        if (_window is not null)
+        {
+            return;
+        }
+
+        var window = _serviceProvider.GetRequiredService<ProjectorWindow>();
+        window.DataContext = _serviceProvider.GetRequiredService<ProjectorViewModel>();
+        window.WindowState = WindowState.Maximized;
+        window.WindowStyle = WindowStyle.None;
+        window.ResizeMode = ResizeMode.NoResize;
+
+        var screens = System.Windows.Forms.Screen.AllScreens;
+        var targetIndex = _screenSelectionService.ProjectorScreenIndex;
+        if (targetIndex.HasValue && targetIndex.Value >= 0 && targetIndex.Value < screens.Length)
+        {
+            var workingArea = screens[targetIndex.Value].WorkingArea;
+            window.Left = workingArea.Left;
+            window.Top = workingArea.Top;
+            window.Width = workingArea.Width;
+            window.Height = workingArea.Height;
+        }
+
+        window.Show();
+        _window = window;
+    }
+}

--- a/Ozge.App/Ozge.App.csproj
+++ b/Ozge.App/Ozge.App.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationIcon>Assets\\ozge.ico</ApplicationIcon>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.4.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\Ozge.Core\\Ozge.Core.csproj" />
+    <ProjectReference Include="..\\Ozge.Data\\Ozge.Data.csproj" />
+    <ProjectReference Include="..\\Ozge.Ocr\\Ozge.Ocr.csproj" />
+    <ProjectReference Include="..\\Ozge.Assets\\Ozge.Assets.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Resource Include="Assets\\ozge.ico" />
+  </ItemGroup>
+</Project>

--- a/Ozge.App/Resources/Styles.xaml
+++ b/Ozge.App/Resources/Styles.xaml
@@ -1,0 +1,10 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="PrimaryBrush" Color="#FF006494" />
+    <Style TargetType="Button">
+        <Setter Property="Margin" Value="0,4,0,0" />
+        <Setter Property="Padding" Value="12,6" />
+        <Setter Property="Background" Value="{StaticResource PrimaryBrush}" />
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+</ResourceDictionary>

--- a/Ozge.App/Services/ImmutableAppStateStore.cs
+++ b/Ozge.App/Services/ImmutableAppStateStore.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Ozge.Core.Domain.Entities;
+using Ozge.Core.Services;
+using Ozge.Data.Context;
+
+namespace Ozge.App.Services;
+
+public class ImmutableAppStateStore : IAppStateStore
+{
+    private readonly OzgeDbContext _dbContext;
+    private readonly ILogger<ImmutableAppStateStore> _logger;
+    private readonly BehaviorSubject<AppStateSnapshot> _subject = new(AppStateSnapshot.Empty);
+
+    public ImmutableAppStateStore(OzgeDbContext dbContext, ILogger<ImmutableAppStateStore> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public AppStateSnapshot Current => _subject.Value;
+
+    public IObservable<AppStateSnapshot> Changes => _subject.AsObservable();
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var classes = await _dbContext.Classes.AsNoTracking().ToListAsync(cancellationToken);
+        var groups = await _dbContext.Groups.AsNoTracking().ToListAsync(cancellationToken);
+        var units = await _dbContext.Units.AsNoTracking().ToListAsync(cancellationToken);
+        var words = await _dbContext.Words.AsNoTracking().ToListAsync(cancellationToken);
+        var questions = await _dbContext.Questions.AsNoTracking().ToListAsync(cancellationToken);
+        var sessions = await _dbContext.Sessions.AsNoTracking().ToListAsync(cancellationToken);
+        var scoreEvents = await _dbContext.ScoreEvents.AsNoTracking().ToListAsync(cancellationToken);
+        var behaviorEvents = await _dbContext.BehaviorEvents.AsNoTracking().ToListAsync(cancellationToken);
+        var snapshots = await _dbContext.Snapshots.AsNoTracking().ToListAsync(cancellationToken);
+        var lessonLogs = await _dbContext.LessonLogs.AsNoTracking().ToListAsync(cancellationToken);
+        var attendance = await _dbContext.Attendance.AsNoTracking().ToListAsync(cancellationToken);
+        var settings = await _dbContext.Settings.AsNoTracking().ToListAsync(cancellationToken);
+
+        var snapshot = new AppStateSnapshot(
+            classes.FirstOrDefault() ?? new ClassEntity { Id = Guid.Empty, Name = "" },
+            classes,
+            groups.GroupBy(g => g.ClassId).ToDictionary(g => g.Key, g => (IReadOnlyList<GroupEntity>)g.ToList()),
+            units.GroupBy(u => u.ClassId).ToDictionary(u => u.Key, u => (IReadOnlyList<UnitEntity>)u.ToList()),
+            questions.GroupBy(q => q.UnitId).ToDictionary(q => q.Key, q => (IReadOnlyList<QuestionEntity>)q.ToList()),
+            words.GroupBy(w => w.UnitId).ToDictionary(w => w.Key, w => (IReadOnlyList<WordEntity>)w.ToList()),
+            sessions.GroupBy(s => s.ClassId).ToDictionary(s => s.Key, s => (IReadOnlyList<SessionEntity>)s.ToList()),
+            scoreEvents.GroupBy(s => s.ClassId).ToDictionary(s => s.Key, s => (IReadOnlyList<ScoreEventEntity>)s.ToList()),
+            behaviorEvents.GroupBy(b => b.ClassId).ToDictionary(b => b.Key, b => (IReadOnlyList<BehaviorEventEntity>)b.ToList()),
+            snapshots.GroupBy(s => s.ClassId).ToDictionary(s => s.Key, s => (IReadOnlyList<SnapshotEntity>)s.ToList()),
+            lessonLogs.GroupBy(l => l.ClassId).ToDictionary(l => l.Key, l => (IReadOnlyList<LessonLogEntity>)l.ToList()),
+            attendance.GroupBy(a => a.ClassId).ToDictionary(a => a.Key, a => (IReadOnlyList<AttendanceEntity>)a.ToList()),
+            settings.GroupBy(s => s.ClassId).ToDictionary(s => s.Key, s => (IReadOnlyDictionary<string, string>)s.ToDictionary(x => x.Key, x => x.Value)),
+            DateTimeOffset.UtcNow);
+
+        _subject.OnNext(snapshot);
+    }
+
+    public void Reduce(Func<AppStateSnapshot, AppStateSnapshot> reducer)
+    {
+        var updated = reducer(_subject.Value);
+        _subject.OnNext(updated with { LastUpdated = DateTimeOffset.UtcNow });
+    }
+}

--- a/Ozge.App/Services/ScreenSelectionService.cs
+++ b/Ozge.App/Services/ScreenSelectionService.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using Ozge.Core.Services;
+using Ozge.Data.Context;
+
+namespace Ozge.App.Services;
+
+public class ScreenSelectionService : IScreenSelectionService
+{
+    private readonly OzgeDbContext _dbContext;
+    private int? _projectorIndex;
+
+    public ScreenSelectionService(OzgeDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public int? ProjectorScreenIndex => _projectorIndex;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var setting = _dbContext.Settings.FirstOrDefault(s => s.Key == "projectorScreenIndex");
+        if (setting is not null && int.TryParse(setting.Value, out var index))
+        {
+            _projectorIndex = index;
+        }
+    }
+
+    public async Task SetProjectorScreenIndexAsync(int index, CancellationToken cancellationToken = default)
+    {
+        _projectorIndex = index;
+        var setting = _dbContext.Settings.FirstOrDefault(s => s.Key == "projectorScreenIndex");
+        if (setting is null)
+        {
+            setting = new Core.Domain.Entities.SettingEntity
+            {
+                Id = Guid.NewGuid(),
+                ClassId = Guid.Empty,
+                Key = "projectorScreenIndex",
+                Value = index.ToString()
+            };
+            _dbContext.Settings.Add(setting);
+        }
+        else
+        {
+            setting.Value = index.ToString();
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Ozge.App/ViewModels/ProjectorViewModel.cs
+++ b/Ozge.App/ViewModels/ProjectorViewModel.cs
@@ -1,0 +1,21 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Ozge.Core.Services;
+
+namespace Ozge.App.ViewModels;
+
+public partial class ProjectorViewModel : ObservableObject
+{
+    private readonly IAppStateStore _stateStore;
+
+    [ObservableProperty]
+    private string _activeMode = "HOME";
+
+    [ObservableProperty]
+    private bool _isAnswerRevealed;
+
+    public ProjectorViewModel(IAppStateStore stateStore)
+    {
+        _stateStore = stateStore;
+        _stateStore.Changes.Subscribe(_ => { });
+    }
+}

--- a/Ozge.App/ViewModels/TeacherDashboardViewModel.cs
+++ b/Ozge.App/ViewModels/TeacherDashboardViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Forms;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Ozge.Core.Domain.Entities;
+using Ozge.Core.Services;
+
+namespace Ozge.App.ViewModels;
+
+public partial class TeacherDashboardViewModel : ObservableObject
+{
+    private readonly IAppStateStore _stateStore;
+    private readonly IScreenSelectionService _screenSelectionService;
+
+    [ObservableProperty]
+    private ClassEntity? _activeClass;
+
+    public ObservableCollection<ClassEntity> Classes { get; } = new();
+    public ObservableCollection<GroupEntity> Groups { get; } = new();
+    public ObservableCollection<UnitEntity> Units { get; } = new();
+
+    [ObservableProperty]
+    private string _selectedMode = "HOME";
+
+    public TeacherDashboardViewModel(IAppStateStore stateStore, IScreenSelectionService screenSelectionService)
+    {
+        _stateStore = stateStore;
+        _screenSelectionService = screenSelectionService;
+
+        _stateStore.Changes.Subscribe(OnStateChanged);
+    }
+
+    private void OnStateChanged(AppStateSnapshot snapshot)
+    {
+        App.Current.Dispatcher.Invoke(() =>
+        {
+            Classes.SyncWith(snapshot.Classes);
+            var active = snapshot.ActiveClass;
+            ActiveClass = active;
+            if (active is not null)
+            {
+                Groups.SyncWith(snapshot.Groups.GetValueOrDefault(active.Id, Array.Empty<GroupEntity>()));
+                Units.SyncWith(snapshot.Units.GetValueOrDefault(active.Id, Array.Empty<UnitEntity>()));
+            }
+        });
+    }
+
+    [RelayCommand]
+    private async Task SetProjectorScreenAsync()
+    {
+        var screens = System.Windows.Forms.Screen.AllScreens;
+        if (screens.Length == 0)
+        {
+            return;
+        }
+        var nextIndex = ((_screenSelectionService.ProjectorScreenIndex ?? -1) + 1) % screens.Length;
+        await _screenSelectionService.SetProjectorScreenIndexAsync(nextIndex);
+    }
+}
+
+public static class ObservableCollectionExtensions
+{
+    public static void SyncWith<T>(this ObservableCollection<T> collection, IEnumerable<T> items)
+    {
+        collection.Clear();
+        foreach (var item in items)
+        {
+            collection.Add(item);
+        }
+    }
+}

--- a/Ozge.App/Views/ProjectorWindow.xaml
+++ b/Ozge.App/Views/ProjectorWindow.xaml
@@ -1,0 +1,24 @@
+<Window x:Class="Ozge.App.Views.ProjectorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Özge2 Projector"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False">
+    <Grid Background="#FF101820">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12">
+            <TextBlock Text="Özge2"
+                       Foreground="White"
+                       FontSize="48"
+                       HorizontalAlignment="Center" />
+            <TextBlock Text="Projector Mode"
+                       Foreground="White"
+                       FontSize="28"
+                       HorizontalAlignment="Center" />
+            <TextBlock Text="{Binding ActiveMode}"
+                       Foreground="LightGray"
+                       FontSize="24"
+                       HorizontalAlignment="Center" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ozge.App/Views/ProjectorWindow.xaml.cs
+++ b/Ozge.App/Views/ProjectorWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Ozge.App.Views;
+
+public partial class ProjectorWindow : Window
+{
+    public ProjectorWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/Ozge.App/Views/TeacherDashboardWindow.xaml
+++ b/Ozge.App/Views/TeacherDashboardWindow.xaml
@@ -1,0 +1,65 @@
+<Window x:Class="Ozge.App.Views.TeacherDashboardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Özge2 Teacher Dashboard"
+        Width="1024"
+        Height="768"
+        WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="220" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0" Margin="12" Spacing="8">
+            <TextBlock Text="Classes" FontWeight="Bold" />
+            <ListBox ItemsSource="{Binding Classes}" SelectedItem="{Binding ActiveClass}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <Button Content="Cycle Projector Screen" Command="{Binding SetProjectorScreenCommand}" />
+            <TextBlock Text="Modes" FontWeight="Bold" Margin="0,16,0,0" />
+            <ListBox SelectedItem="{Binding SelectedMode}">
+                <ListBoxItem Content="HOME" />
+                <ListBoxItem Content="QUIZ" />
+                <ListBoxItem Content="PUZZLE" />
+                <ListBoxItem Content="SPEAK" />
+                <ListBoxItem Content="STORY" />
+                <ListBoxItem Content="DRAW" />
+                <ListBoxItem Content="BONUS" />
+                <ListBoxItem Content="RESULT" />
+            </ListBox>
+        </StackPanel>
+        <Grid Grid.Column="1" Margin="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <TextBlock Text="Overview" FontSize="18" FontWeight="Bold" />
+            <TabControl Grid.Row="1" Margin="0,12,0,0">
+                <TabItem Header="Groups">
+                    <ListView ItemsSource="{Binding Groups}">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="120" />
+                                <GridViewColumn Header="Score" DisplayMemberBinding="{Binding Score}" Width="80" />
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </TabItem>
+                <TabItem Header="Units">
+                    <ListView ItemsSource="{Binding Units}">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="200" />
+                                <GridViewColumn Header="Topic" DisplayMemberBinding="{Binding Topic}" Width="200" />
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </TabItem>
+            </TabControl>
+        </Grid>
+    </Grid>
+</Window>

--- a/Ozge.App/Views/TeacherDashboardWindow.xaml.cs
+++ b/Ozge.App/Views/TeacherDashboardWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Ozge.App.Views;
+
+public partial class TeacherDashboardWindow : Window
+{
+    public TeacherDashboardWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/Ozge.App/appsettings.json
+++ b/Ozge.App/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/Ozge.Assets/Ozge.Assets.csproj
+++ b/Ozge.Assets/Ozge.Assets.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressWarnings>NU1507</SuppressWarnings>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="tessdata\\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="images\\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="sounds\\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/Ozge.Core/Domain/Entities/AttendanceEntity.cs
+++ b/Ozge.Core/Domain/Entities/AttendanceEntity.cs
@@ -1,0 +1,12 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class AttendanceEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public Guid StudentId { get; set; }
+    public DateOnly Date { get; set; }
+    public bool Present { get; set; }
+    public StudentEntity? Student { get; set; }
+    public ClassEntity? Class { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/BehaviorEventEntity.cs
+++ b/Ozge.Core/Domain/Entities/BehaviorEventEntity.cs
@@ -1,0 +1,13 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class BehaviorEventEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public Guid GroupId { get; set; }
+    public string Kind { get; set; } = string.Empty;
+    public DateTimeOffset Timestamp { get; set; }
+    public string Note { get; set; } = string.Empty;
+    public GroupEntity? Group { get; set; }
+    public ClassEntity? Class { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/ClassEntity.cs
+++ b/Ozge.Core/Domain/Entities/ClassEntity.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Ozge.Core.Domain.Entities;
+
+public class ClassEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string SettingsJson { get; set; } = "{}";
+    public ICollection<StudentEntity> Students { get; set; } = new List<StudentEntity>();
+    public ICollection<GroupEntity> Groups { get; set; } = new List<GroupEntity>();
+    public ICollection<UnitEntity> Units { get; set; } = new List<UnitEntity>();
+    public ICollection<SessionEntity> Sessions { get; set; } = new List<SessionEntity>();
+    public ICollection<ScoreEventEntity> ScoreEvents { get; set; } = new List<ScoreEventEntity>();
+    public ICollection<BehaviorEventEntity> BehaviorEvents { get; set; } = new List<BehaviorEventEntity>();
+    public ICollection<SnapshotEntity> Snapshots { get; set; } = new List<SnapshotEntity>();
+    public ICollection<LessonLogEntity> LessonLogs { get; set; } = new List<LessonLogEntity>();
+    public ICollection<SettingEntity> Settings { get; set; } = new List<SettingEntity>();
+}

--- a/Ozge.Core/Domain/Entities/GroupEntity.cs
+++ b/Ozge.Core/Domain/Entities/GroupEntity.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Ozge.Core.Domain.Entities;
+
+public class GroupEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Avatar { get; set; } = string.Empty;
+    public int Score { get; set; }
+    public ClassEntity? Class { get; set; }
+    public ICollection<ScoreEventEntity> ScoreEvents { get; set; } = new List<ScoreEventEntity>();
+    public ICollection<BehaviorEventEntity> BehaviorEvents { get; set; } = new List<BehaviorEventEntity>();
+}

--- a/Ozge.Core/Domain/Entities/JobEntity.cs
+++ b/Ozge.Core/Domain/Entities/JobEntity.cs
@@ -1,0 +1,14 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class JobEntity
+{
+    public Guid Id { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string PayloadJson { get; set; } = "{}";
+    public string Status { get; set; } = "Pending";
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
+    public DateTimeOffset? ScheduledAt { get; set; }
+    public int RetryCount { get; set; }
+    public string? Error { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/LessonLogEntity.cs
+++ b/Ozge.Core/Domain/Entities/LessonLogEntity.cs
@@ -1,0 +1,12 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class LessonLogEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public Guid? SessionId { get; set; }
+    public string DataJson { get; set; } = "{}";
+    public DateTimeOffset Timestamp { get; set; }
+    public ClassEntity? Class { get; set; }
+    public SessionEntity? Session { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/QuestionEntity.cs
+++ b/Ozge.Core/Domain/Entities/QuestionEntity.cs
@@ -1,0 +1,13 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class QuestionEntity
+{
+    public Guid Id { get; set; }
+    public Guid UnitId { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Prompt { get; set; } = string.Empty;
+    public string Correct { get; set; } = string.Empty;
+    public string OptionsJson { get; set; } = "[]";
+    public string Difficulty { get; set; } = "easy";
+    public UnitEntity? Unit { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/ScoreEventEntity.cs
+++ b/Ozge.Core/Domain/Entities/ScoreEventEntity.cs
@@ -1,0 +1,13 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class ScoreEventEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public Guid GroupId { get; set; }
+    public int Delta { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public DateTimeOffset Timestamp { get; set; }
+    public GroupEntity? Group { get; set; }
+    public ClassEntity? Class { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/SessionEntity.cs
+++ b/Ozge.Core/Domain/Entities/SessionEntity.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Ozge.Core.Domain.Entities;
+
+public class SessionEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public Guid? UnitId { get; set; }
+    public string Mode { get; set; } = string.Empty;
+    public DateTimeOffset StartedAt { get; set; }
+    public DateTimeOffset? EndedAt { get; set; }
+    public ClassEntity? Class { get; set; }
+    public UnitEntity? Unit { get; set; }
+    public ICollection<LessonLogEntity> LessonLogs { get; set; } = new List<LessonLogEntity>();
+}

--- a/Ozge.Core/Domain/Entities/SettingEntity.cs
+++ b/Ozge.Core/Domain/Entities/SettingEntity.cs
@@ -1,0 +1,10 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class SettingEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public ClassEntity? Class { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/SnapshotEntity.cs
+++ b/Ozge.Core/Domain/Entities/SnapshotEntity.cs
@@ -1,0 +1,12 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class SnapshotEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public Guid? UnitId { get; set; }
+    public string Path { get; set; } = string.Empty;
+    public DateTimeOffset Timestamp { get; set; }
+    public ClassEntity? Class { get; set; }
+    public UnitEntity? Unit { get; set; }
+}

--- a/Ozge.Core/Domain/Entities/StudentEntity.cs
+++ b/Ozge.Core/Domain/Entities/StudentEntity.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Ozge.Core.Domain.Entities;
+
+public class StudentEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Seat { get; set; } = string.Empty;
+    public bool IsActive { get; set; } = true;
+    public ClassEntity? Class { get; set; }
+    public ICollection<AttendanceEntity> AttendanceRecords { get; set; } = new List<AttendanceEntity>();
+}

--- a/Ozge.Core/Domain/Entities/UnitEntity.cs
+++ b/Ozge.Core/Domain/Entities/UnitEntity.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Ozge.Core.Domain.Entities;
+
+public class UnitEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClassId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Topic { get; set; } = string.Empty;
+    public string MetaJson { get; set; } = "{}";
+    public ClassEntity? Class { get; set; }
+    public ICollection<WordEntity> Words { get; set; } = new List<WordEntity>();
+    public ICollection<QuestionEntity> Questions { get; set; } = new List<QuestionEntity>();
+}

--- a/Ozge.Core/Domain/Entities/WordEntity.cs
+++ b/Ozge.Core/Domain/Entities/WordEntity.cs
@@ -1,0 +1,12 @@
+namespace Ozge.Core.Domain.Entities;
+
+public class WordEntity
+{
+    public Guid Id { get; set; }
+    public Guid UnitId { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public string PartOfSpeech { get; set; } = string.Empty;
+    public string Difficulty { get; set; } = "easy";
+    public string MetaJson { get; set; } = "{}";
+    public UnitEntity? Unit { get; set; }
+}

--- a/Ozge.Core/Messaging/AppMessages.cs
+++ b/Ozge.Core/Messaging/AppMessages.cs
@@ -1,0 +1,6 @@
+namespace Ozge.Core.Messaging;
+
+public record ProjectorRevealChangedMessage(bool IsRevealed);
+public record ActiveModeChangedMessage(string Mode);
+public record ScoreUpdatedMessage(Guid ClassId, Guid GroupId, int NewScore);
+public record BehaviorEventMessage(Guid ClassId, Guid GroupId, string Kind);

--- a/Ozge.Core/Ozge.Core.csproj
+++ b/Ozge.Core/Ozge.Core.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+  </ItemGroup>
+</Project>

--- a/Ozge.Core/Serialization/JsonHelper.cs
+++ b/Ozge.Core/Serialization/JsonHelper.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace Ozge.Core.Serialization;
+
+public static class JsonHelper
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    public static string Serialize<T>(T value) => JsonSerializer.Serialize(value, Options);
+
+    public static T? Deserialize<T>(string json) => string.IsNullOrWhiteSpace(json)
+        ? default
+        : JsonSerializer.Deserialize<T>(json, Options);
+}

--- a/Ozge.Core/Services/IAppStateStore.cs
+++ b/Ozge.Core/Services/IAppStateStore.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using Ozge.Core.Domain.Entities;
+
+namespace Ozge.Core.Services;
+
+public interface IAppStateStore
+{
+    AppStateSnapshot Current { get; }
+    IObservable<AppStateSnapshot> Changes { get; }
+    void Reduce(Func<AppStateSnapshot, AppStateSnapshot> reducer);
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+}
+
+public record AppStateSnapshot(
+    ClassEntity ActiveClass,
+    IReadOnlyList<ClassEntity> Classes,
+    IReadOnlyDictionary<Guid, IReadOnlyList<GroupEntity>> Groups,
+    IReadOnlyDictionary<Guid, IReadOnlyList<UnitEntity>> Units,
+    IReadOnlyDictionary<Guid, IReadOnlyList<QuestionEntity>> Questions,
+    IReadOnlyDictionary<Guid, IReadOnlyList<WordEntity>> Words,
+    IReadOnlyDictionary<Guid, IReadOnlyList<SessionEntity>> Sessions,
+    IReadOnlyDictionary<Guid, IReadOnlyList<ScoreEventEntity>> ScoreEvents,
+    IReadOnlyDictionary<Guid, IReadOnlyList<BehaviorEventEntity>> BehaviorEvents,
+    IReadOnlyDictionary<Guid, IReadOnlyList<SnapshotEntity>> Snapshots,
+    IReadOnlyDictionary<Guid, IReadOnlyList<LessonLogEntity>> LessonLogs,
+    IReadOnlyDictionary<Guid, IReadOnlyList<AttendanceEntity>> Attendance,
+    IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, string>> Settings,
+    DateTimeOffset LastUpdated)
+{
+    public static AppStateSnapshot Empty { get; } = new(
+        new ClassEntity { Id = Guid.Empty, Name = "" },
+        Array.Empty<ClassEntity>(),
+        new Dictionary<Guid, IReadOnlyList<GroupEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<UnitEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<QuestionEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<WordEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<SessionEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<ScoreEventEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<BehaviorEventEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<SnapshotEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<LessonLogEntity>>(),
+        new Dictionary<Guid, IReadOnlyList<AttendanceEntity>>(),
+        new Dictionary<Guid, IReadOnlyDictionary<string, string>>(),
+        DateTimeOffset.MinValue);
+}

--- a/Ozge.Core/Services/IDatabaseInitializer.cs
+++ b/Ozge.Core/Services/IDatabaseInitializer.cs
@@ -1,0 +1,6 @@
+namespace Ozge.Core.Services;
+
+public interface IDatabaseInitializer
+{
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+}

--- a/Ozge.Core/Services/IScreenSelectionService.cs
+++ b/Ozge.Core/Services/IScreenSelectionService.cs
@@ -1,0 +1,8 @@
+namespace Ozge.Core.Services;
+
+public interface IScreenSelectionService
+{
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+    int? ProjectorScreenIndex { get; }
+    Task SetProjectorScreenIndexAsync(int index, CancellationToken cancellationToken = default);
+}

--- a/Ozge.Data/Configurations/ClassEntityConfiguration.cs
+++ b/Ozge.Data/Configurations/ClassEntityConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ozge.Core.Domain.Entities;
+
+namespace Ozge.Data.Configurations;
+
+public class ClassEntityConfiguration : IEntityTypeConfiguration<ClassEntity>
+{
+    public void Configure(EntityTypeBuilder<ClassEntity> builder)
+    {
+        builder.ToTable("Classes");
+        builder.HasKey(c => c.Id);
+        builder.Property(c => c.Name).HasMaxLength(64).IsRequired();
+        builder.Property(c => c.SettingsJson).HasColumnType("TEXT");
+    }
+}

--- a/Ozge.Data/Configurations/EntityConfigurations.cs
+++ b/Ozge.Data/Configurations/EntityConfigurations.cs
@@ -1,0 +1,170 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ozge.Core.Domain.Entities;
+
+namespace Ozge.Data.Configurations;
+
+public class StudentEntityConfiguration : IEntityTypeConfiguration<StudentEntity>
+{
+    public void Configure(EntityTypeBuilder<StudentEntity> builder)
+    {
+        builder.ToTable("Students");
+        builder.HasKey(s => s.Id);
+        builder.Property(s => s.Name).HasMaxLength(128).IsRequired();
+        builder.Property(s => s.Seat).HasMaxLength(16);
+        builder.HasIndex(s => new { s.ClassId, s.Name });
+    }
+}
+
+public class GroupEntityConfiguration : IEntityTypeConfiguration<GroupEntity>
+{
+    public void Configure(EntityTypeBuilder<GroupEntity> builder)
+    {
+        builder.ToTable("Groups");
+        builder.HasKey(g => g.Id);
+        builder.Property(g => g.Name).HasMaxLength(32).IsRequired();
+        builder.Property(g => g.Avatar).HasMaxLength(64);
+        builder.HasIndex(g => new { g.ClassId, g.Name }).IsUnique();
+    }
+}
+
+public class UnitEntityConfiguration : IEntityTypeConfiguration<UnitEntity>
+{
+    public void Configure(EntityTypeBuilder<UnitEntity> builder)
+    {
+        builder.ToTable("Units");
+        builder.HasKey(u => u.Id);
+        builder.Property(u => u.Name).HasMaxLength(128).IsRequired();
+        builder.Property(u => u.Topic).HasMaxLength(128);
+        builder.Property(u => u.MetaJson).HasColumnType("TEXT");
+        builder.HasIndex(u => new { u.ClassId, u.Name }).IsUnique();
+    }
+}
+
+public class WordEntityConfiguration : IEntityTypeConfiguration<WordEntity>
+{
+    public void Configure(EntityTypeBuilder<WordEntity> builder)
+    {
+        builder.ToTable("Words");
+        builder.HasKey(w => w.Id);
+        builder.Property(w => w.Text).HasMaxLength(128).IsRequired();
+        builder.Property(w => w.PartOfSpeech).HasMaxLength(32);
+        builder.Property(w => w.Difficulty).HasMaxLength(16);
+        builder.Property(w => w.MetaJson).HasColumnType("TEXT");
+        builder.HasIndex(w => new { w.UnitId, w.Text }).IsUnique();
+    }
+}
+
+public class QuestionEntityConfiguration : IEntityTypeConfiguration<QuestionEntity>
+{
+    public void Configure(EntityTypeBuilder<QuestionEntity> builder)
+    {
+        builder.ToTable("Questions");
+        builder.HasKey(q => q.Id);
+        builder.Property(q => q.Type).HasMaxLength(32).IsRequired();
+        builder.Property(q => q.Prompt).HasColumnType("TEXT").IsRequired();
+        builder.Property(q => q.Correct).HasColumnType("TEXT").IsRequired();
+        builder.Property(q => q.OptionsJson).HasColumnType("TEXT");
+        builder.Property(q => q.Difficulty).HasMaxLength(16);
+        builder.HasIndex(q => new { q.UnitId, q.Type });
+    }
+}
+
+public class SessionEntityConfiguration : IEntityTypeConfiguration<SessionEntity>
+{
+    public void Configure(EntityTypeBuilder<SessionEntity> builder)
+    {
+        builder.ToTable("Sessions");
+        builder.HasKey(s => s.Id);
+        builder.Property(s => s.Mode).HasMaxLength(32);
+        builder.HasIndex(s => new { s.ClassId, s.StartedAt });
+    }
+}
+
+public class ScoreEventEntityConfiguration : IEntityTypeConfiguration<ScoreEventEntity>
+{
+    public void Configure(EntityTypeBuilder<ScoreEventEntity> builder)
+    {
+        builder.ToTable("ScoreEvents");
+        builder.HasKey(s => s.Id);
+        builder.Property(s => s.Reason).HasMaxLength(128);
+        builder.Property(s => s.Timestamp).HasConversion(v => v.UtcDateTime, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+        builder.HasIndex(s => new { s.ClassId, s.Timestamp });
+    }
+}
+
+public class BehaviorEventEntityConfiguration : IEntityTypeConfiguration<BehaviorEventEntity>
+{
+    public void Configure(EntityTypeBuilder<BehaviorEventEntity> builder)
+    {
+        builder.ToTable("BehaviorEvents");
+        builder.HasKey(b => b.Id);
+        builder.Property(b => b.Kind).HasMaxLength(32);
+        builder.Property(b => b.Note).HasColumnType("TEXT");
+        builder.Property(b => b.Timestamp).HasConversion(v => v.UtcDateTime, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+        builder.HasIndex(b => new { b.ClassId, b.Timestamp });
+    }
+}
+
+public class SnapshotEntityConfiguration : IEntityTypeConfiguration<SnapshotEntity>
+{
+    public void Configure(EntityTypeBuilder<SnapshotEntity> builder)
+    {
+        builder.ToTable("Snapshots");
+        builder.HasKey(s => s.Id);
+        builder.Property(s => s.Path).HasMaxLength(512);
+        builder.Property(s => s.Timestamp).HasConversion(v => v.UtcDateTime, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+        builder.HasIndex(s => new { s.ClassId, s.Timestamp });
+    }
+}
+
+public class SettingEntityConfiguration : IEntityTypeConfiguration<SettingEntity>
+{
+    public void Configure(EntityTypeBuilder<SettingEntity> builder)
+    {
+        builder.ToTable("Settings");
+        builder.HasKey(s => s.Id);
+        builder.Property(s => s.Key).HasMaxLength(64).IsRequired();
+        builder.Property(s => s.Value).HasColumnType("TEXT");
+        builder.HasIndex(s => new { s.ClassId, s.Key }).IsUnique();
+    }
+}
+
+public class AttendanceEntityConfiguration : IEntityTypeConfiguration<AttendanceEntity>
+{
+    public void Configure(EntityTypeBuilder<AttendanceEntity> builder)
+    {
+        builder.ToTable("Attendance");
+        builder.HasKey(a => a.Id);
+        builder.Property(a => a.Date).HasConversion(
+            v => v.ToDateTime(TimeOnly.MinValue),
+            v => DateOnly.FromDateTime(DateTime.SpecifyKind(v, DateTimeKind.Utc)));
+        builder.HasIndex(a => new { a.ClassId, a.StudentId, a.Date }).IsUnique();
+    }
+}
+
+public class LessonLogEntityConfiguration : IEntityTypeConfiguration<LessonLogEntity>
+{
+    public void Configure(EntityTypeBuilder<LessonLogEntity> builder)
+    {
+        builder.ToTable("LessonLogs");
+        builder.HasKey(l => l.Id);
+        builder.Property(l => l.DataJson).HasColumnType("TEXT");
+        builder.Property(l => l.Timestamp).HasConversion(v => v.UtcDateTime, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+        builder.HasIndex(l => new { l.ClassId, l.Timestamp });
+    }
+}
+
+public class JobEntityConfiguration : IEntityTypeConfiguration<JobEntity>
+{
+    public void Configure(EntityTypeBuilder<JobEntity> builder)
+    {
+        builder.ToTable("Jobs");
+        builder.HasKey(j => j.Id);
+        builder.Property(j => j.Type).HasMaxLength(64).IsRequired();
+        builder.Property(j => j.Status).HasMaxLength(32);
+        builder.Property(j => j.PayloadJson).HasColumnType("TEXT");
+        builder.Property(j => j.Error).HasColumnType("TEXT");
+        builder.HasIndex(j => j.Status);
+    }
+}

--- a/Ozge.Data/Context/OzgeDbContext.cs
+++ b/Ozge.Data/Context/OzgeDbContext.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Ozge.Core.Domain.Entities;
+
+namespace Ozge.Data.Context;
+
+public class OzgeDbContext : DbContext
+{
+    public OzgeDbContext(DbContextOptions<OzgeDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<ClassEntity> Classes => Set<ClassEntity>();
+    public DbSet<StudentEntity> Students => Set<StudentEntity>();
+    public DbSet<GroupEntity> Groups => Set<GroupEntity>();
+    public DbSet<UnitEntity> Units => Set<UnitEntity>();
+    public DbSet<WordEntity> Words => Set<WordEntity>();
+    public DbSet<QuestionEntity> Questions => Set<QuestionEntity>();
+    public DbSet<SessionEntity> Sessions => Set<SessionEntity>();
+    public DbSet<ScoreEventEntity> ScoreEvents => Set<ScoreEventEntity>();
+    public DbSet<BehaviorEventEntity> BehaviorEvents => Set<BehaviorEventEntity>();
+    public DbSet<SnapshotEntity> Snapshots => Set<SnapshotEntity>();
+    public DbSet<SettingEntity> Settings => Set<SettingEntity>();
+    public DbSet<AttendanceEntity> Attendance => Set<AttendanceEntity>();
+    public DbSet<LessonLogEntity> LessonLogs => Set<LessonLogEntity>();
+    public DbSet<JobEntity> Jobs => Set<JobEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OzgeDbContext).Assembly);
+    }
+}

--- a/Ozge.Data/Extensions/SqliteOptionsBuilderExtensions.cs
+++ b/Ozge.Data/Extensions/SqliteOptionsBuilderExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Ozge.Data.Context;
+
+namespace Ozge.Data.Extensions;
+
+public static class SqliteOptionsBuilderExtensions
+{
+    public static IServiceCollection AddOzgeSqlite(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<OzgeDbContext>(options =>
+        {
+            var connectionString = BuildConnectionString();
+            options.UseSqlite(connectionString);
+            options.EnableSensitiveDataLogging(false);
+        });
+
+        return services;
+    }
+
+    public static string BuildConnectionString()
+    {
+        var databasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Ozge2", "ozge2.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(databasePath)!);
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            ForeignKeys = true,
+            Cache = SqliteCacheMode.Private
+        };
+
+        return builder.ToString();
+    }
+
+    public static void ApplyRecommendedPragmas(this SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA cache_size=-20000; PRAGMA busy_timeout=5000;";
+        command.ExecuteNonQuery();
+    }
+}

--- a/Ozge.Data/Migrations/20240101000000_InitialCreate.cs
+++ b/Ozge.Data/Migrations/20240101000000_InitialCreate.cs
@@ -1,0 +1,474 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ozge.Data.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Classes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    SettingsJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Classes", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Jobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Type = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    PayloadJson = table.Column<string>(type: "TEXT", nullable: false),
+                    Status = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    ScheduledAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    RetryCount = table.Column<int>(type: "INTEGER", nullable: false),
+                    Error = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Jobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Jobs_Status",
+                table: "Jobs",
+                column: "Status");
+
+            migrationBuilder.CreateTable(
+                name: "Groups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    Avatar = table.Column<string>(type: "TEXT", maxLength: 64, nullable: true),
+                    Score = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Groups", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Groups_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Groups_ClassId_Name",
+                table: "Groups",
+                columns: new[] { "ClassId", "Name" },
+                unique: true);
+
+            migrationBuilder.CreateTable(
+                name: "Settings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Key = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    Value = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Settings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Settings_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Settings_ClassId_Key",
+                table: "Settings",
+                columns: new[] { "ClassId", "Key" },
+                unique: true);
+
+            migrationBuilder.CreateTable(
+                name: "Students",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                    Seat = table.Column<string>(type: "TEXT", maxLength: 16, nullable: true),
+                    IsActive = table.Column<bool>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Students", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Students_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Students_ClassId_Name",
+                table: "Students",
+                columns: new[] { "ClassId", "Name" });
+
+            migrationBuilder.CreateTable(
+                name: "Units",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                    Topic = table.Column<string>(type: "TEXT", maxLength: 128, nullable: true),
+                    MetaJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Units", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Units_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Units_ClassId_Name",
+                table: "Units",
+                columns: new[] { "ClassId", "Name" },
+                unique: true);
+
+            migrationBuilder.CreateTable(
+                name: "Attendance",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    StudentId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Date = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Present = table.Column<bool>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Attendance", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Attendance_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Attendance_Students_StudentId",
+                        column: x => x.StudentId,
+                        principalTable: "Students",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Attendance_ClassId_StudentId_Date",
+                table: "Attendance",
+                columns: new[] { "ClassId", "StudentId", "Date" },
+                unique: true);
+
+
+            migrationBuilder.CreateTable(
+                name: "Sessions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UnitId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    Mode = table.Column<string>(type: "TEXT", maxLength: 32, nullable: true),
+                    StartedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    EndedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sessions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Sessions_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Sessions_Units_UnitId",
+                        column: x => x.UnitId,
+                        principalTable: "Units",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_ClassId_StartedAt",
+                table: "Sessions",
+                columns: new[] { "ClassId", "StartedAt" });
+
+            migrationBuilder.CreateTable(
+                name: "Words",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UnitId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Text = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                    PartOfSpeech = table.Column<string>(type: "TEXT", maxLength: 32, nullable: true),
+                    Difficulty = table.Column<string>(type: "TEXT", maxLength: 16, nullable: true),
+                    MetaJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Words", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Words_Units_UnitId",
+                        column: x => x.UnitId,
+                        principalTable: "Units",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Words_UnitId_Text",
+                table: "Words",
+                columns: new[] { "UnitId", "Text" },
+                unique: true);
+
+            migrationBuilder.CreateTable(
+                name: "BehaviorEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    GroupId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Kind = table.Column<string>(type: "TEXT", maxLength: 32, nullable: true),
+                    Timestamp = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    Note = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BehaviorEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BehaviorEvents_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BehaviorEvents_Groups_GroupId",
+                        column: x => x.GroupId,
+                        principalTable: "Groups",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BehaviorEvents_ClassId_Timestamp",
+                table: "BehaviorEvents",
+                columns: new[] { "ClassId", "Timestamp" });
+
+            migrationBuilder.CreateTable(
+                name: "Questions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UnitId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Type = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    Prompt = table.Column<string>(type: "TEXT", nullable: false),
+                    Correct = table.Column<string>(type: "TEXT", nullable: false),
+                    OptionsJson = table.Column<string>(type: "TEXT", nullable: true),
+                    Difficulty = table.Column<string>(type: "TEXT", maxLength: 16, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Questions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Questions_Units_UnitId",
+                        column: x => x.UnitId,
+                        principalTable: "Units",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Questions_UnitId_Type",
+                table: "Questions",
+                columns: new[] { "UnitId", "Type" });
+
+            migrationBuilder.CreateTable(
+                name: "ScoreEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    GroupId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Delta = table.Column<int>(type: "INTEGER", nullable: false),
+                    Reason = table.Column<string>(type: "TEXT", maxLength: 128, nullable: true),
+                    Timestamp = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScoreEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScoreEvents_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ScoreEvents_Groups_GroupId",
+                        column: x => x.GroupId,
+                        principalTable: "Groups",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoreEvents_ClassId_Timestamp",
+                table: "ScoreEvents",
+                columns: new[] { "ClassId", "Timestamp" });
+
+            migrationBuilder.CreateTable(
+                name: "Snapshots",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UnitId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    Path = table.Column<string>(type: "TEXT", maxLength: 512, nullable: false),
+                    Timestamp = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Snapshots", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Snapshots_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Snapshots_Units_UnitId",
+                        column: x => x.UnitId,
+                        principalTable: "Units",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Snapshots_ClassId_Timestamp",
+                table: "Snapshots",
+                columns: new[] { "ClassId", "Timestamp" });
+
+            migrationBuilder.CreateTable(
+                name: "LessonLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ClassId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    SessionId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    DataJson = table.Column<string>(type: "TEXT", nullable: false),
+                    Timestamp = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LessonLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LessonLogs_Classes_ClassId",
+                        column: x => x.ClassId,
+                        principalTable: "Classes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LessonLogs_Sessions_SessionId",
+                        column: x => x.SessionId,
+                        principalTable: "Sessions",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LessonLogs_ClassId_Timestamp",
+                table: "LessonLogs",
+                columns: new[] { "ClassId", "Timestamp" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LessonLogs_SessionId",
+                table: "LessonLogs",
+                column: "SessionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Attendance_StudentId",
+                table: "Attendance",
+                column: "StudentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BehaviorEvents_GroupId",
+                table: "BehaviorEvents",
+                column: "GroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Questions_UnitId",
+                table: "Questions",
+                column: "UnitId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoreEvents_GroupId",
+                table: "ScoreEvents",
+                column: "GroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_UnitId",
+                table: "Sessions",
+                column: "UnitId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Snapshots_UnitId",
+                table: "Snapshots",
+                column: "UnitId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Students_ClassId",
+                table: "Students",
+                column: "ClassId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Units_ClassId",
+                table: "Units",
+                column: "ClassId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Words_UnitId",
+                table: "Words",
+                column: "UnitId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "Attendance");
+            migrationBuilder.DropTable(name: "BehaviorEvents");
+            migrationBuilder.DropTable(name: "Jobs");
+            migrationBuilder.DropTable(name: "LessonLogs");
+            migrationBuilder.DropTable(name: "Questions");
+            migrationBuilder.DropTable(name: "ScoreEvents");
+            migrationBuilder.DropTable(name: "Settings");
+            migrationBuilder.DropTable(name: "Snapshots");
+            migrationBuilder.DropTable(name: "Words");
+            migrationBuilder.DropTable(name: "Sessions");
+            migrationBuilder.DropTable(name: "Groups");
+            migrationBuilder.DropTable(name: "Students");
+            migrationBuilder.DropTable(name: "Units");
+            migrationBuilder.DropTable(name: "Classes");
+        }
+    }
+}

--- a/Ozge.Data/Migrations/OzgeDbContextModelSnapshot.cs
+++ b/Ozge.Data/Migrations/OzgeDbContextModelSnapshot.cs
@@ -1,0 +1,410 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Ozge.Data.Context;
+
+#nullable disable
+
+namespace Ozge.Data.Migrations
+{
+    [DbContext(typeof(OzgeDbContext))]
+    partial class OzgeDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.2");
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.AttendanceEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<DateTime>("Date").HasColumnType("TEXT");
+                b.Property<bool>("Present").HasColumnType("INTEGER");
+                b.Property<Guid>("StudentId").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("StudentId");
+                b.HasIndex("ClassId", "StudentId", "Date").IsUnique();
+                b.ToTable("Attendance");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.BehaviorEventEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<Guid>("GroupId").HasColumnType("TEXT");
+                b.Property<string>("Kind").HasMaxLength(32).HasColumnType("TEXT");
+                b.Property<string>("Note").HasColumnType("TEXT");
+                b.Property<DateTimeOffset>("Timestamp").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("GroupId");
+                b.HasIndex("ClassId", "Timestamp");
+                b.ToTable("BehaviorEvents");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.ClassEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<string>("Name").HasMaxLength(64).HasColumnType("TEXT");
+                b.Property<string>("SettingsJson").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.ToTable("Classes");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.GroupEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<string>("Avatar").HasMaxLength(64).HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<string>("Name").HasMaxLength(32).HasColumnType("TEXT");
+                b.Property<int>("Score").HasColumnType("INTEGER");
+                b.HasKey("Id");
+                b.HasIndex("ClassId");
+                b.HasIndex("ClassId", "Name").IsUnique();
+                b.ToTable("Groups");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.JobEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<string>("Error").HasColumnType("TEXT");
+                b.Property<string>("PayloadJson").HasColumnType("TEXT");
+                b.Property<string>("Status").HasMaxLength(32).HasColumnType("TEXT");
+                b.Property<string>("Type").HasMaxLength(64).HasColumnType("TEXT");
+                b.Property<DateTimeOffset>("CreatedAt").HasColumnType("TEXT");
+                b.Property<int>("RetryCount").HasColumnType("INTEGER");
+                b.Property<DateTimeOffset?>("ScheduledAt").HasColumnType("TEXT");
+                b.Property<DateTimeOffset?>("UpdatedAt").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("Status");
+                b.ToTable("Jobs");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.LessonLogEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<string>("DataJson").HasColumnType("TEXT");
+                b.Property<Guid?>("SessionId").HasColumnType("TEXT");
+                b.Property<DateTimeOffset>("Timestamp").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("SessionId");
+                b.HasIndex("ClassId", "Timestamp");
+                b.ToTable("LessonLogs");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.QuestionEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<string>("Correct").HasColumnType("TEXT");
+                b.Property<string>("Difficulty").HasMaxLength(16).HasColumnType("TEXT");
+                b.Property<string>("OptionsJson").HasColumnType("TEXT");
+                b.Property<string>("Prompt").HasColumnType("TEXT");
+                b.Property<string>("Type").HasMaxLength(32).HasColumnType("TEXT");
+                b.Property<Guid>("UnitId").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("UnitId");
+                b.HasIndex("UnitId", "Type");
+                b.ToTable("Questions");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.ScoreEventEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<int>("Delta").HasColumnType("INTEGER");
+                b.Property<Guid>("GroupId").HasColumnType("TEXT");
+                b.Property<string>("Reason").HasMaxLength(128).HasColumnType("TEXT");
+                b.Property<DateTimeOffset>("Timestamp").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("GroupId");
+                b.HasIndex("ClassId", "Timestamp");
+                b.ToTable("ScoreEvents");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.SessionEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<string>("Mode").HasMaxLength(32).HasColumnType("TEXT");
+                b.Property<DateTimeOffset?>("EndedAt").HasColumnType("TEXT");
+                b.Property<DateTimeOffset>("StartedAt").HasColumnType("TEXT");
+                b.Property<Guid?>("UnitId").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("UnitId");
+                b.HasIndex("ClassId", "StartedAt");
+                b.ToTable("Sessions");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.SettingEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<string>("Key").HasMaxLength(64).HasColumnType("TEXT");
+                b.Property<string>("Value").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("ClassId");
+                b.HasIndex("ClassId", "Key").IsUnique();
+                b.ToTable("Settings");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.SnapshotEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<string>("Path").HasMaxLength(512).HasColumnType("TEXT");
+                b.Property<DateTimeOffset>("Timestamp").HasColumnType("TEXT");
+                b.Property<Guid?>("UnitId").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("UnitId");
+                b.HasIndex("ClassId", "Timestamp");
+                b.ToTable("Snapshots");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.StudentEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<bool>("IsActive").HasColumnType("INTEGER");
+                b.Property<string>("Name").HasMaxLength(128).HasColumnType("TEXT");
+                b.Property<string>("Seat").HasMaxLength(16).HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("ClassId");
+                b.HasIndex("ClassId", "Name");
+                b.ToTable("Students");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.UnitEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<Guid>("ClassId").HasColumnType("TEXT");
+                b.Property<string>("MetaJson").HasColumnType("TEXT");
+                b.Property<string>("Name").HasMaxLength(128).HasColumnType("TEXT");
+                b.Property<string>("Topic").HasMaxLength(128).HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("ClassId");
+                b.HasIndex("ClassId", "Name").IsUnique();
+                b.ToTable("Units");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.WordEntity", b =>
+            {
+                b.Property<Guid>("Id").HasColumnType("TEXT");
+                b.Property<string>("Difficulty").HasMaxLength(16).HasColumnType("TEXT");
+                b.Property<string>("MetaJson").HasColumnType("TEXT");
+                b.Property<string>("PartOfSpeech").HasMaxLength(32).HasColumnType("TEXT");
+                b.Property<string>("Text").HasMaxLength(128).HasColumnType("TEXT");
+                b.Property<Guid>("UnitId").HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("UnitId");
+                b.HasIndex("UnitId", "Text").IsUnique();
+                b.ToTable("Words");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.AttendanceEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany()
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Ozge.Core.Domain.Entities.StudentEntity", "Student")
+                    .WithMany("AttendanceRecords")
+                    .HasForeignKey("StudentId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Class");
+                b.Navigation("Student");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.BehaviorEventEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("BehaviorEvents")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Ozge.Core.Domain.Entities.GroupEntity", "Group")
+                    .WithMany("BehaviorEvents")
+                    .HasForeignKey("GroupId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Class");
+                b.Navigation("Group");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.GroupEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("Groups")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Class");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.LessonLogEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("LessonLogs")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Ozge.Core.Domain.Entities.SessionEntity", "Session")
+                    .WithMany()
+                    .HasForeignKey("SessionId");
+
+                b.Navigation("Class");
+                b.Navigation("Session");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.QuestionEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.UnitEntity", "Unit")
+                    .WithMany("Questions")
+                    .HasForeignKey("UnitId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Unit");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.ScoreEventEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("ScoreEvents")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Ozge.Core.Domain.Entities.GroupEntity", "Group")
+                    .WithMany("ScoreEvents")
+                    .HasForeignKey("GroupId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Class");
+                b.Navigation("Group");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.SessionEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("Sessions")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Ozge.Core.Domain.Entities.UnitEntity", "Unit")
+                    .WithMany()
+                    .HasForeignKey("UnitId");
+
+                b.Navigation("Class");
+                b.Navigation("Unit");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.SettingEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("Settings")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Class");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.SnapshotEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("Snapshots")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Ozge.Core.Domain.Entities.UnitEntity", "Unit")
+                    .WithMany()
+                    .HasForeignKey("UnitId");
+
+                b.Navigation("Class");
+                b.Navigation("Unit");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.StudentEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("Students")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Class");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.UnitEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.ClassEntity", "Class")
+                    .WithMany("Units")
+                    .HasForeignKey("ClassId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Class");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.WordEntity", b =>
+            {
+                b.HasOne("Ozge.Core.Domain.Entities.UnitEntity", "Unit")
+                    .WithMany("Words")
+                    .HasForeignKey("UnitId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Unit");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.ClassEntity", b =>
+            {
+                b.Navigation("BehaviorEvents");
+                b.Navigation("Groups");
+                b.Navigation("LessonLogs");
+                b.Navigation("ScoreEvents");
+                b.Navigation("Sessions");
+                b.Navigation("Settings");
+                b.Navigation("Snapshots");
+                b.Navigation("Students");
+                b.Navigation("Units");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.GroupEntity", b =>
+            {
+                b.Navigation("BehaviorEvents");
+                b.Navigation("ScoreEvents");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.SessionEntity", b =>
+            {
+                b.Navigation("LessonLogs");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.StudentEntity", b =>
+            {
+                b.Navigation("AttendanceRecords");
+            });
+
+            modelBuilder.Entity("Ozge.Core.Domain.Entities.UnitEntity", b =>
+            {
+                b.Navigation("Questions");
+                b.Navigation("Words");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/Ozge.Data/Ozge.Data.csproj
+++ b/Ozge.Data/Ozge.Data.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\Ozge.Core\\Ozge.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Ozge.Data/Services/DatabaseInitializer.cs
+++ b/Ozge.Data/Services/DatabaseInitializer.cs
@@ -1,0 +1,120 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Ozge.Core.Domain.Entities;
+using Ozge.Core.Services;
+using Ozge.Data.Context;
+using Ozge.Data.Extensions;
+
+namespace Ozge.Data.Services;
+
+public class DatabaseInitializer : IDatabaseInitializer
+{
+    private readonly OzgeDbContext _dbContext;
+    private readonly ILogger<DatabaseInitializer> _logger;
+
+    public DatabaseInitializer(OzgeDbContext dbContext, ILogger<DatabaseInitializer> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Ozge2"));
+
+        if (_dbContext.Database.GetDbConnection() is SqliteConnection sqliteConnection)
+        {
+            sqliteConnection.Open();
+            sqliteConnection.ApplyRecommendedPragmas();
+        }
+
+        await _dbContext.Database.MigrateAsync(cancellationToken);
+        await SeedAsync(cancellationToken);
+    }
+
+    private async Task SeedAsync(CancellationToken cancellationToken)
+    {
+        if (await _dbContext.Classes.AnyAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var classNames = new[] { "5A", "5B", "5C", "5D" };
+
+        foreach (var className in classNames)
+        {
+            var classEntity = new ClassEntity
+            {
+                Id = Guid.NewGuid(),
+                Name = className,
+                SettingsJson = "{}"
+            };
+
+            var groups = Enumerable.Range(0, 8).Select(i => new GroupEntity
+            {
+                Id = Guid.NewGuid(),
+                ClassId = classEntity.Id,
+                Name = ((char)('A' + i)).ToString(),
+                Avatar = $"avatar_{i}",
+                Score = 0
+            }).ToList();
+
+            var students = Enumerable.Range(1, 24).Select(i => new StudentEntity
+            {
+                Id = Guid.NewGuid(),
+                ClassId = classEntity.Id,
+                Name = $"Student {i}",
+                Seat = i.ToString("D2"),
+                IsActive = true
+            }).ToList();
+
+            var units = Enumerable.Range(1, 5).Select(u => new UnitEntity
+            {
+                Id = Guid.NewGuid(),
+                ClassId = classEntity.Id,
+                Name = $"Unit {u}",
+                Topic = $"Topic {u}",
+                MetaJson = "{}"
+            }).ToList();
+
+            var words = new List<WordEntity>();
+            var questions = new List<QuestionEntity>();
+
+            foreach (var unit in units)
+            {
+                var unitWords = Enumerable.Range(1, 20).Select(idx => new WordEntity
+                {
+                    Id = Guid.NewGuid(),
+                    UnitId = unit.Id,
+                    Text = $"Word {idx}",
+                    PartOfSpeech = idx % 2 == 0 ? "noun" : "verb",
+                    Difficulty = idx % 3 == 0 ? "medium" : "easy",
+                    MetaJson = "{}"
+                }).ToList();
+
+                words.AddRange(unitWords);
+
+                questions.AddRange(unitWords.Take(5).Select(word => new QuestionEntity
+                {
+                    Id = Guid.NewGuid(),
+                    UnitId = unit.Id,
+                    Type = "Quiz",
+                    Prompt = $"Select the definition of {word.Text}",
+                    Correct = word.Text,
+                    OptionsJson = "[]",
+                    Difficulty = word.Difficulty
+                }));
+            }
+
+            _dbContext.Classes.Add(classEntity);
+            _dbContext.Groups.AddRange(groups);
+            _dbContext.Students.AddRange(students);
+            _dbContext.Units.AddRange(units);
+            _dbContext.Words.AddRange(words);
+            _dbContext.Questions.AddRange(questions);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Ozge.Ocr/Ozge.Ocr.csproj
+++ b/Ozge.Ocr/Ozge.Ocr.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="UglyToad.PdfPig" Version="0.0.8" />
+    <PackageReference Include="Tesseract" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\Ozge.Core\\Ozge.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Ozge.Ocr/Parsing/ParsedContent.cs
+++ b/Ozge.Ocr/Parsing/ParsedContent.cs
@@ -1,0 +1,14 @@
+namespace Ozge.Ocr.Parsing;
+
+public record ParsedContent(
+    IReadOnlyList<ParsedUnit> Units,
+    IReadOnlyList<string> Diagnostics);
+
+public record ParsedUnit(
+    string Name,
+    string Topic,
+    IReadOnlyList<string> Words,
+    IReadOnlyList<string> Sentences,
+    IReadOnlyList<string> Questions);
+
+public record ContentSource(string Path, byte[]? Data = null, string? ContentType = null);

--- a/Ozge.Ocr/Services/IContentParser.cs
+++ b/Ozge.Ocr/Services/IContentParser.cs
@@ -1,0 +1,8 @@
+using Ozge.Ocr.Parsing;
+
+namespace Ozge.Ocr.Services;
+
+public interface IContentParser
+{
+    Task<ParsedContent> ParseAsync(ContentSource source, CancellationToken cancellationToken = default);
+}

--- a/Ozge.Ocr/Services/OfflineContentParser.cs
+++ b/Ozge.Ocr/Services/OfflineContentParser.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Ozge.Ocr.Parsing;
+using UglyToad.PdfPig;
+
+namespace Ozge.Ocr.Services;
+
+public class OfflineContentParser : IContentParser
+{
+    public Task<ParsedContent> ParseAsync(ContentSource source, CancellationToken cancellationToken = default)
+    {
+        if (source.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(ParsePdf(source.Path));
+        }
+
+        return Task.FromResult(new ParsedContent(Array.Empty<ParsedUnit>(), new[] { "No parser available for source." }));
+    }
+
+    private ParsedContent ParsePdf(string path)
+    {
+        var diagnostics = new List<string>();
+        var units = new List<ParsedUnit>();
+
+        if (!File.Exists(path))
+        {
+            diagnostics.Add($"File not found: {path}");
+            return new ParsedContent(units, diagnostics);
+        }
+
+        using var document = PdfDocument.Open(path);
+        var text = string.Join(Environment.NewLine, document.GetPages().Select(p => p.Text));
+        var words = text.Split(new[] { '\r', '\n', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .Where(w => w.Length > 3)
+            .Take(50)
+            .ToList();
+
+        var unit = new ParsedUnit("Imported Unit", "General", words, words.Take(10).ToList(), words.Take(5).ToList());
+        units.Add(unit);
+        diagnostics.Add($"Parsed {words.Count} words from PDF.");
+        return new ParsedContent(units, diagnostics);
+    }
+}

--- a/Ozge.sln
+++ b/Ozge.sln
@@ -1,0 +1,45 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ozge.App", "Ozge.App\\Ozge.App.csproj", "{8C5E0C19-8B59-4A04-AC1F-047A3E1E2AAF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ozge.Core", "Ozge.Core\\Ozge.Core.csproj", "{0E3DA627-5B83-4E26-8A32-6B3537DD1B14}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ozge.Data", "Ozge.Data\\Ozge.Data.csproj", "{9D11F7B6-75C6-465D-B6A2-99C5D63049FE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ozge.Ocr", "Ozge.Ocr\\Ozge.Ocr.csproj", "{3E999478-61AA-4EC0-A39E-77A88DC86537}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ozge.Assets", "Ozge.Assets\\Ozge.Assets.csproj", "{AE7F5918-8B89-41C0-8D64-A77190A60E71}"
+EndProject
+Global
+\tGlobalSection(SolutionConfigurationPlatforms) = preSolution
+\t\tDebug|Any CPU = Debug|Any CPU
+\t\tRelease|Any CPU = Release|Any CPU
+\tEndGlobalSection
+\tGlobalSection(ProjectConfigurationPlatforms) = postSolution
+\t\t{8C5E0C19-8B59-4A04-AC1F-047A3E1E2AAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+\t\t{8C5E0C19-8B59-4A04-AC1F-047A3E1E2AAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+\t\t{8C5E0C19-8B59-4A04-AC1F-047A3E1E2AAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+\t\t{8C5E0C19-8B59-4A04-AC1F-047A3E1E2AAF}.Release|Any CPU.Build.0 = Release|Any CPU
+\t\t{0E3DA627-5B83-4E26-8A32-6B3537DD1B14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+\t\t{0E3DA627-5B83-4E26-8A32-6B3537DD1B14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+\t\t{0E3DA627-5B83-4E26-8A32-6B3537DD1B14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+\t\t{0E3DA627-5B83-4E26-8A32-6B3537DD1B14}.Release|Any CPU.Build.0 = Release|Any CPU
+\t\t{9D11F7B6-75C6-465D-B6A2-99C5D63049FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+\t\t{9D11F7B6-75C6-465D-B6A2-99C5D63049FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+\t\t{9D11F7B6-75C6-465D-B6A2-99C5D63049FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+\t\t{9D11F7B6-75C6-465D-B6A2-99C5D63049FE}.Release|Any CPU.Build.0 = Release|Any CPU
+\t\t{3E999478-61AA-4EC0-A39E-77A88DC86537}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+\t\t{3E999478-61AA-4EC0-A39E-77A88DC86537}.Debug|Any CPU.Build.0 = Debug|Any CPU
+\t\t{3E999478-61AA-4EC0-A39E-77A88DC86537}.Release|Any CPU.ActiveCfg = Release|Any CPU
+\t\t{3E999478-61AA-4EC0-A39E-77A88DC86537}.Release|Any CPU.Build.0 = Release|Any CPU
+\t\t{AE7F5918-8B89-41C0-8D64-A77190A60E71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+\t\t{AE7F5918-8B89-41C0-8D64-A77190A60E71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+\t\t{AE7F5918-8B89-41C0-8D64-A77190A60E71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+\t\t{AE7F5918-8B89-41C0-8D64-A77190A60E71}.Release|Any CPU.Build.0 = Release|Any CPU
+\tEndGlobalSection
+\tGlobalSection(SolutionProperties) = preSolution
+\t\tHideSolutionNode = FALSE
+\tEndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# Codex
+# Özge2 Classroom Suite
+
+This repository contains a .NET 8 WPF solution scaffold for the **Özge2** dual-screen classroom application. The codebase is organised into layered projects following an onion/hexagonal architecture and targets offline-first deployments with SQLite persistence.
+
+## Solution Layout
+
+```
+/Ozge.sln                Solution file referencing all projects
+/Ozge.App               WPF presentation layer (Teacher + Projector windows)
+/Ozge.Core              Domain entities, contracts and helpers
+/Ozge.Data              Entity Framework Core persistence + seeding
+/Ozge.Ocr               Offline content parsing pipeline abstractions
+/Ozge.Assets            Resource container for tessdata/images/sounds
+/publish                Output directory for single-file builds
+```
+
+## Getting Started
+
+1. Install the .NET 8 SDK and the EF Core CLI tools.
+2. (Optional) Populate `Ozge.Assets/tessdata` with Tesseract language packs (e.g. `eng.traineddata`).
+3. Run the helper script to restore, migrate and publish:
+   ```powershell
+   ./build_publish.ps1
+   ```
+4. Launch the generated `publish/Ozge.App.exe` (rename to `Ozge2.exe` if desired). On first run, the app seeds demo data for classes 5A–5D and opens the Teacher Dashboard window. The Projector window is launched on the configured display; use the “Cycle Projector Screen” button to select the correct monitor and the setting is stored in the local SQLite database at `%LOCALAPPDATA%\Ozge2\ozge2.db`.
+
+## Dual-Screen Operation
+
+- **TeacherDashboardWindow** (primary monitor): provides class selection, group scores and control toggles. Only the Teacher view shows correct answers and moderation controls.
+- **ProjectorWindow** (secondary monitor): full-screen, student-facing display. The sample implementation displays the active mode name and can be expanded to support full gameplay experiences.
+
+## Data & Persistence
+
+- SQLite database lives under `%LOCALAPPDATA%/Ozge2/ozge2.db` with Write-Ahead Logging and tuned PRAGMA settings for resilience.
+- `DatabaseInitializer` automatically migrates schema and seeds demo classes, groups, students, units, words and quiz questions for rapid evaluation.
+- `ImmutableAppStateStore` provides an in-memory, observable snapshot of key entities shared between the Teacher and Projector windows.
+
+## Content Pipeline
+
+`Ozge.Ocr` ships with an `OfflineContentParser` that demonstrates PDF ingestion using UglyToad.PdfPig. The parser reads local PDF files and extracts a simple list of candidate words, producing a single unit placeholder. Extend this component to plug in OCR (Tesseract) and richer clustering heuristics.
+
+## Build Notes
+
+- Projects target `net8.0` / `net8.0-windows` and already reference key packages (CommunityToolkit.Mvvm, EF Core, PdfPig, Tesseract, LiveCharts, Serilog).
+- Publishing uses single-file, self-contained options as required. Update the `build_publish.ps1` script to include additional assets or trimming preferences if necessary.
+- Asset folders (`Ozge.Assets/images`, `Ozge.Assets/sounds`, `Ozge.Assets/tessdata`) are placeholders—place runtime resources there and ensure the publish profile copies them to `%LOCALAPPDATA%/Ozge2` on first launch.
+
+## Next Steps
+
+The current implementation focuses on scaffolding, data models, and dual-window bootstrapping. Implement mode-specific gameplay, analytics, speech processing, drawing canvas logic, backup rotation, content manager workflows, and the remaining requirements iteratively while keeping the offline, resilient architecture intact.

--- a/build_publish.ps1
+++ b/build_publish.ps1
@@ -1,0 +1,18 @@
+param(
+    [string]$Configuration = "Release",
+    [string]$Runtime = "win-x64"
+)
+
+Write-Host "Restoring packages..."
+dotnet restore Ozge.sln
+
+Write-Host "Building..."
+dotnet build Ozge.sln -c $Configuration
+
+Write-Host "Applying database migrations..."
+dotnet ef database update --project Ozge.Data --startup-project Ozge.App --context Ozge.Data.Context.OzgeDbContext -c $Configuration
+
+Write-Host "Publishing single-file package..."
+dotnet publish Ozge.App -c $Configuration -r $Runtime --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o publish
+
+Write-Host "Publish complete. Output located at ./publish/Ozge2.exe if rename is required."


### PR DESCRIPTION
## Summary
- scaffold the Ozge2 solution with WPF presentation, domain core, EF Core data access, OCR services, and asset projects
- implement SQLite-backed DbContext with schema migrations, seed data, and application state store wiring via the generic host
- add teacher dashboard and projector windows with dual-screen activation services and build/publish automation script

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4a6a1a954832883bc5623164cd6a8