### PR TITLE
Refine quiz dashboard menus and celebration audio support

### DIFF
--- a/Ozge.App/Infrastructure/SoundEffectPlayer.cs
+++ b/Ozge.App/Infrastructure/SoundEffectPlayer.cs
@@ -27,6 +27,8 @@ public sealed class SoundEffectPlayer : ISoundEffectPlayer, IDisposable
 
     public Task PlayIncorrectAsync() => PlayInternalAsync(_settingsService.Current.IncorrectSoundPath);
 
+    public Task PlayCelebrationAsync() => PlayInternalAsync(_settingsService.Current.CelebrationSoundPath);
+
     public Task PreviewAsync(string? filePath) => PlayInternalAsync(filePath);
 
     private Task PlayInternalAsync(string? filePath)

--- a/Ozge.App/Infrastructure/SoundSettings.cs
+++ b/Ozge.App/Infrastructure/SoundSettings.cs
@@ -4,8 +4,9 @@ namespace Ozge.App.Infrastructure;
 
 public sealed record SoundSettings(
     [property: JsonPropertyName("correctSoundPath")] string? CorrectSoundPath,
-    [property: JsonPropertyName("incorrectSoundPath")] string? IncorrectSoundPath)
+    [property: JsonPropertyName("incorrectSoundPath")] string? IncorrectSoundPath,
+    [property: JsonPropertyName("celebrationSoundPath")] string? CelebrationSoundPath)
 {
-    public static SoundSettings Default { get; } = new(null, null);
+    public static SoundSettings Default { get; } = new(null, null, null);
 }
 

--- a/Ozge.App/Presentation/ViewModels/ProjectorViewModel.cs
+++ b/Ozge.App/Presentation/ViewModels/ProjectorViewModel.cs
@@ -245,6 +245,14 @@ public sealed partial class ProjectorViewModel : ViewModelBase, IRecipient<AppSt
         }
     }
 
+    partial void OnShowCelebrationChanged(bool value)
+    {
+        if (value)
+        {
+            _ = _soundEffectPlayer.PlayCelebrationAsync();
+        }
+    }
+
     private void ResetOptionStates()
     {
         foreach (var option in QuizOptions)

--- a/Ozge.App/Presentation/ViewModels/QuestionBankItemViewModel.cs
+++ b/Ozge.App/Presentation/ViewModels/QuestionBankItemViewModel.cs
@@ -5,16 +5,23 @@ namespace Ozge.App.Presentation.ViewModels;
 
 public sealed class QuestionBankItemViewModel
 {
-    public QuestionBankItemViewModel(string prompt, string correctAnswer, IEnumerable<string> options)
+    public QuestionBankItemViewModel(int order, string prompt, string correctAnswer, IEnumerable<string> options)
     {
+        Order = order;
         Prompt = prompt;
         CorrectAnswer = correctAnswer;
         Options = new ObservableCollection<string>(options);
     }
+
+    public int Order { get; }
 
     public string Prompt { get; }
 
     public string CorrectAnswer { get; }
 
     public ObservableCollection<string> Options { get; }
+
+    public int OptionCount => Options.Count;
+
+    public string DisplayOrder => $"{Order}. soru";
 }

--- a/Ozge.App/Presentation/Windows/ProjectorWindow.xaml
+++ b/Ozge.App/Presentation/Windows/ProjectorWindow.xaml
@@ -325,37 +325,7 @@
         <Grid x:Name="CelebrationOverlay"
               Visibility="{Binding ShowCelebration, Converter={StaticResource BooleanToVisibilityConverter}}">
             <StackPanel HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        RenderTransformOrigin="0.5,0.5">
-                <StackPanel.RenderTransform>
-                    <ScaleTransform x:Name="CelebrationScale" />
-                </StackPanel.RenderTransform>
-                <StackPanel.Style>
-                    <Style TargetType="StackPanel">
-                        <Setter Property="Opacity" Value="0" />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding ShowCelebration}" Value="True">
-                                <Setter Property="Opacity" Value="1" />
-                                <DataTrigger.EnterActions>
-                                    <BeginStoryboard>
-                                        <Storyboard RepeatBehavior="Forever">
-                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX"
-                                                             From="0.9"
-                                                             To="1.05"
-                                                             Duration="0:0:2"
-                                                             AutoReverse="True" />
-                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY"
-                                                             From="0.9"
-                                                             To="1.05"
-                                                             Duration="0:0:2"
-                                                             AutoReverse="True" />
-                                        </Storyboard>
-                                    </BeginStoryboard>
-                                </DataTrigger.EnterActions>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </StackPanel.Style>
+                        VerticalAlignment="Center">
                 <TextBlock Text="Harika İş!"
                            FontSize="80"
                            FontWeight="Black"

--- a/Ozge.App/Presentation/Windows/TeacherDashboardWindow.xaml
+++ b/Ozge.App/Presentation/Windows/TeacherDashboardWindow.xaml
@@ -389,491 +389,675 @@
                               Visibility="{Binding IsQuizMenuActive, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 
-                            <WrapPanel Grid.Row="0"
-                                       Margin="0,0,0,16">
-                                <StackPanel Width="220"
-                                            Margin="0,0,16,12">
-                                    <TextBlock Text="Sinif Secimi"
-                                               FontSize="13"
-                                               FontWeight="SemiBold"
-                                               Opacity="0.85" />
-                                    <ComboBox ItemsSource="{Binding Classes}"
-                                              SelectedItem="{Binding SelectedClass, Mode=TwoWay}"
-                                              DisplayMemberPath="Name"
-                                              Padding="8,4"
-                                              Background="#1B2238"
-                                              Foreground="White" />
-                                </StackPanel>
-                                <StackPanel Width="220"
-                                            Margin="0,0,16,12">
-                                    <TextBlock Text="Uniteler"
-                                               FontSize="13"
-                                               FontWeight="SemiBold"
-                                               Opacity="0.85" />
-                                    <ComboBox ItemsSource="{Binding SelectedClass.Units}"
-                                              SelectedItem="{Binding SelectedUnit, Mode=TwoWay}"
-                                              DisplayMemberPath="Name"
-                                              Padding="8,4"
-                                              Background="#1B2238"
-                                              Foreground="White" />
-                                </StackPanel>
-                                <StackPanel Margin="0,0,16,12">
-                                    <TextBlock Text="Secili Unite"
-                                               FontSize="13"
-                                               FontWeight="SemiBold"
-                                               Opacity="0.85" />
-                                    <TextBlock Text="{Binding SelectedUnit.Topic, StringFormat=Konu: {0}}"
-                                               Margin="0,6,0,0"
-                                               Opacity="0.8" />
-                                    <TextBlock Text="{Binding SelectedUnit.QuestionCount, StringFormat=Toplam Soru: {0}}"
-                                               Opacity="0.8" />
-                                </StackPanel>
-                            </WrapPanel>
+                            <ListBox Grid.Row="0"
+                                     Margin="0,0,0,20"
+                                     ItemsSource="{Binding QuizSubMenus}"
+                                     SelectedItem="{Binding SelectedQuizSubMenu, Mode=TwoWay}"
+                                     BorderThickness="0"
+                                     Background="Transparent"
+                                     HorizontalAlignment="Left"
+                                     ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                                     ItemContainerStyle="{StaticResource QuizSubMenuItemStyle}">
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" />
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type viewModels:QuizSubMenuOptionViewModel}">
+                                        <TextBlock Text="{Binding Title}"
+                                                   FontWeight="SemiBold" />
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
 
-                            <WrapPanel Grid.Row="1"
-                                       Margin="0,0,0,12">
-                                <Button Content="Quiz Baslat"
-                                        Style="{StaticResource AccentButtonStyle}"
-                                        Command="{Binding StartQuizCommand}"
-                                        IsEnabled="{Binding CanStartQuiz}"
-                                        Margin="0,0,12,12" />
-                                <Button Content="{Binding PreviousQuestionButtonText}"
-                                        Style="{StaticResource SecondaryButtonStyle}"
-                                        Command="{Binding PreviousQuestionCommand}"
-                                        IsEnabled="{Binding CanGoBackQuestion}"
-                                        Margin="0,0,12,12" />
-                                <Button Content="{Binding NextQuestionButtonText}"
-                                        Style="{StaticResource SecondaryButtonStyle}"
-                                        Command="{Binding NextQuestionCommand}"
-                                        IsEnabled="{Binding CanAdvanceQuestion}"
-                                        Margin="0,0,12,12" />
-                        <Button Content="Soru Ekle"
-                                Style="{StaticResource AccentButtonStyle}"
-                                Command="{Binding AddQuestionCommand}"
-                                Margin="0,0,12,12" />
-                        <Button Content="Soruyu Duzenle"
-                                Style="{StaticResource SecondaryButtonStyle}"
-                                Command="{Binding EditCurrentQuestionCommand}"
-                                Margin="0,0,12,12" />
-                        <Button Content="Quiz Bitir"
-                                Style="{StaticResource SecondaryButtonStyle}"
-                                Command="{Binding EndQuizCommand}"
-                                IsEnabled="{Binding CanEndQuiz}"
-                                        Margin="0,0,12,12" />
-                                <Button Content="{Binding AnswerRevealButtonText}"
-                                        Style="{StaticResource AccentButtonStyle}"
-                                        Command="{Binding ToggleAnswerRevealCommand}"
-                                        Margin="0,0,12,12" />
-                            </WrapPanel>
+                            <Grid Grid.Row="1">
+                                <Grid x:Name="QuizControlContent"
+                                      Visibility="{Binding IsQuizControlSubMenuActive, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
 
-                            <StackPanel Grid.Row="2"
-                                        Orientation="Horizontal"
-                                        Visibility="{Binding IsQuizLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                <ProgressBar Width="160"
-                                             Height="10"
-                                             IsIndeterminate="True"
-                                             Margin="0,0,8,0" />
-                                <TextBlock Text="Quiz yukleniyor..."
-                                           VerticalAlignment="Center" />
-                            </StackPanel>
-
-                            <StackPanel Grid.Row="3"
-                                        Margin="0,12,0,0">
-                                <Border Background="#1B2238"
-                                        CornerRadius="16"
-                                        Padding="16"
-                                        Margin="0,0,0,12"
-                                        Visibility="{Binding IsQuestionEditMode, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                    <StackPanel>
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-                                            <TextBlock Text="Soru Duzenleme"
-                                                       FontSize="18"
-                                                       FontWeight="Bold" />
-                                            <Button Grid.Column="1"
-                                                    Content="Duzenlemeyi Iptal"
-                                                    Style="{StaticResource SecondaryButtonStyle}"
-                                                    Command="{Binding CancelQuestionEditCommand}"
-                                                    Margin="16,0,0,0" />
-                                        </Grid>
-
-                                        <TextBox Text="{Binding EditableQuestionPrompt, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 Margin="0,12,0,12"
-                                                 Background="#12172A"
-                                                 Foreground="White"
-                                                 BorderBrush="{StaticResource TeacherAccentMutedBrush}"
-                                                 Padding="8"
-                                                 AcceptsReturn="True"
-                                                 TextWrapping="Wrap"
-                                                 MinHeight="80" />
-
-                                        <ItemsControl ItemsSource="{Binding EditableQuestionOptions}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate DataType="{x:Type viewModels:EditableQuizOptionViewModel}">
-                                                    <Border Background="#22182C4A"
-                                                            CornerRadius="12"
-                                                            Padding="10"
-                                                            Margin="0,0,0,8">
-                                                        <Grid>
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="Auto" />
-                                                                <ColumnDefinition Width="*" />
-                                                                <ColumnDefinition Width="Auto" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <RadioButton Grid.Column="0"
-                                                                         Margin="0,0,12,0"
-                                                                         VerticalAlignment="Center"
-                                                                         GroupName="CurrentQuestionCorrectOption"
-                                                                         IsChecked="{Binding IsCorrect, Mode=TwoWay}"
-                                                                         Foreground="{StaticResource TeacherAccentBrush}"
-                                                                         ToolTip="Dogru secenek" />
-                                                            <TextBox Grid.Column="1"
-                                                                     Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                                     Background="#12172A"
-                                                                     Foreground="White"
-                                                                     BorderBrush="{StaticResource TeacherAccentMutedBrush}"
-                                                                     Padding="6"
-                                                                     TextWrapping="Wrap" />
-                                                            <Button Grid.Column="2"
-                                                                    Content="Sil"
-                                                                    Style="{StaticResource SecondaryButtonStyle}"
-                                                                    Command="{Binding DataContext.RemoveEditableOptionCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Margin="12,0,0,0" />
-                                                        </Grid>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-
-                                        <StackPanel Orientation="Horizontal"
-                                                    Margin="0,12,0,0">
-                                            <Button Content="Secenek Ekle"
-                                                    Style="{StaticResource SecondaryButtonStyle}"
-                                                    Command="{Binding AddEditableOptionCommand}"
-                                                    Margin="0,0,12,0" />
-                                            <Button Content="Soruyu Kaydet"
-                                                    Style="{StaticResource AccentButtonStyle}"
-                                                    Command="{Binding SaveQuestionEditCommand}" />
+                                    <WrapPanel Grid.Row="0"
+                                               Margin="0,0,0,16">
+                                        <StackPanel Width="220"
+                                                    Margin="0,0,16,12">
+                                            <TextBlock Text="Sinif Secimi"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Opacity="0.85" />
+                                            <ComboBox ItemsSource="{Binding Classes}"
+                                                      SelectedItem="{Binding SelectedClass, Mode=TwoWay}"
+                                                      DisplayMemberPath="Name"
+                                                      Padding="8,4"
+                                                      Background="#1B2238"
+                                                      Foreground="White" />
                                         </StackPanel>
-
-                                        <TextBlock Text="{Binding QuestionEditStatusMessage}"
-                                                   Margin="0,12,0,0"
-                                                   Foreground="{StaticResource TeacherAccentBrush}"
-                                                   TextWrapping="Wrap" />
-                                    </StackPanel>
-                                </Border>
-
-                                <Border Background="#1B2238"
-                                        CornerRadius="16"
-                                        Padding="16">
-                                    <StackPanel>
-                                        <TextBlock Text="Toplu Soru Ekleme"
-                                                   FontSize="18"
-                                                   FontWeight="Bold" />
-                                        <TextBlock Text="Her soruyu bos satirla ayirin. Dogru secenegi '*' ile isaretleyin (ornegin *Dogru cevap)."
-                                                   Margin="0,8,0,12"
-                                                   TextWrapping="Wrap"
-                                                   Opacity="0.75" />
-                                        <TextBox Text="{Binding BulkQuestionInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 AcceptsReturn="True"
-                                                 TextWrapping="Wrap"
-                                                 VerticalScrollBarVisibility="Auto"
-                                                 MinHeight="160"
-                                                 Background="#12172A"
-                                                 Foreground="White"
-                                                 BorderBrush="{StaticResource TeacherAccentMutedBrush}"
-                                                 Padding="8" />
-                                        <StackPanel Orientation="Horizontal"
-                                                    Margin="0,12,0,0">
-                                            <Button Content="Toplu Sorulari Ekle"
-                                                    Style="{StaticResource AccentButtonStyle}"
-                                                    Command="{Binding AddBulkQuestionsCommand}" />
+                                        <StackPanel Width="220"
+                                                    Margin="0,0,16,12">
+                                            <TextBlock Text="Uniteler"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Opacity="0.85" />
+                                            <ComboBox ItemsSource="{Binding SelectedClass.Units}"
+                                                      SelectedItem="{Binding SelectedUnit, Mode=TwoWay}"
+                                                      DisplayMemberPath="Name"
+                                                      Padding="8,4"
+                                                      Background="#1B2238"
+                                                      Foreground="White" />
                                         </StackPanel>
-                                        <TextBlock Text="{Binding BulkQuestionStatusMessage}"
-                                                   Margin="0,12,0,0"
-                                                   Foreground="{StaticResource TeacherAccentBrush}"
-                                                   TextWrapping="Wrap" />
+                                        <StackPanel Margin="0,0,16,12">
+                                            <TextBlock Text="Secili Unite"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Opacity="0.85" />
+                                            <TextBlock Text="{Binding SelectedUnit.Topic, StringFormat=Konu: {0}}"
+                                                       Margin="0,6,0,0"
+                                                       Opacity="0.8" />
+                                            <TextBlock Text="{Binding SelectedUnit.QuestionCount, StringFormat=Toplam Soru: {0}}"
+                                                       Opacity="0.8" />
+                                        </StackPanel>
+                                    </WrapPanel>
+
+                                    <WrapPanel Grid.Row="1"
+                                               Margin="0,0,0,12">
+                                        <Button Content="Quiz Baslat"
+                                                Style="{StaticResource AccentButtonStyle}"
+                                                Command="{Binding StartQuizCommand}"
+                                                IsEnabled="{Binding CanStartQuiz}"
+                                                Margin="0,0,12,12" />
+                                        <Button Content="{Binding PreviousQuestionButtonText}"
+                                                Style="{StaticResource SecondaryButtonStyle}"
+                                                Command="{Binding PreviousQuestionCommand}"
+                                                IsEnabled="{Binding CanGoBackQuestion}"
+                                                Margin="0,0,12,12" />
+                                        <Button Content="{Binding NextQuestionButtonText}"
+                                                Style="{StaticResource SecondaryButtonStyle}"
+                                                Command="{Binding NextQuestionCommand}"
+                                                IsEnabled="{Binding CanAdvanceQuestion}"
+                                                Margin="0,0,12,12" />
+                                        <Button Content="Soru Ekle"
+                                                Style="{StaticResource AccentButtonStyle}"
+                                                Command="{Binding AddQuestionCommand}"
+                                                Margin="0,0,12,12" />
+                                        <Button Content="Soruyu Duzenle"
+                                                Style="{StaticResource SecondaryButtonStyle}"
+                                                Command="{Binding EditCurrentQuestionCommand}"
+                                                Margin="0,0,12,12" />
+                                        <Button Content="Quiz Bitir"
+                                                Style="{StaticResource SecondaryButtonStyle}"
+                                                Command="{Binding EndQuizCommand}"
+                                                IsEnabled="{Binding CanEndQuiz}"
+                                                Margin="0,0,12,12" />
+                                        <Button Content="{Binding AnswerRevealButtonText}"
+                                                Style="{StaticResource AccentButtonStyle}"
+                                                Command="{Binding ToggleAnswerRevealCommand}"
+                                                Margin="0,0,12,12" />
+                                    </WrapPanel>
+
+                                    <StackPanel Grid.Row="2"
+                                                Orientation="Horizontal"
+                                                Visibility="{Binding IsQuizLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        <ProgressBar Width="160"
+                                                     Height="10"
+                                                     IsIndeterminate="True"
+                                                     Margin="0,0,8,0" />
+                                        <TextBlock Text="Quiz yukleniyor..."
+                                                   VerticalAlignment="Center" />
                                     </StackPanel>
-                                </Border>
-                            </StackPanel>
 
-                            <Grid Grid.Row="4"
-                                  Margin="0,20,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="2*" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
+                                    <StackPanel Grid.Row="3"
+                                                Margin="0,12,0,0">
+                                        <Border Background="#1B2238"
+                                                CornerRadius="16"
+                                                Padding="16"
+                                                Margin="0,0,0,12"
+                                                Visibility="{Binding IsQuestionEditMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <StackPanel>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Soru Duzenleme"
+                                                               FontSize="18"
+                                                               FontWeight="Bold" />
+                                                    <Button Grid.Column="1"
+                                                            Content="Duzenlemeyi Iptal"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding CancelQuestionEditCommand}"
+                                                            Margin="16,0,0,0" />
+                                                </Grid>
 
-                                <Border Background="#1B2238"
-                                        CornerRadius="18"
-                                        Padding="20"
-                                        Margin="0,0,20,0">
-                                    <StackPanel>
-                                        <TextBlock Text="{Binding CurrentQuestionTitle}"
+                                                <TextBox Text="{Binding EditableQuestionPrompt, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                         Margin="0,12,0,12"
+                                                         Background="#12172A"
+                                                         Foreground="White"
+                                                         BorderBrush="{StaticResource TeacherAccentMutedBrush}"
+                                                         Padding="8"
+                                                         AcceptsReturn="True"
+                                                         TextWrapping="Wrap"
+                                                         MinHeight="80" />
+
+                                                <ItemsControl ItemsSource="{Binding EditableQuestionOptions}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate DataType="{x:Type viewModels:EditableQuizOptionViewModel}">
+                                                            <Border Background="#22182C4A"
+                                                                    CornerRadius="12"
+                                                                    Padding="10"
+                                                                    Margin="0,0,0,8">
+                                                                <Grid>
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="Auto" />
+                                                                        <ColumnDefinition Width="*" />
+                                                                        <ColumnDefinition Width="Auto" />
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <RadioButton Grid.Column="0"
+                                                                                 Margin="0,0,12,0"
+                                                                                 VerticalAlignment="Center"
+                                                                                 GroupName="CurrentQuestionCorrectOption"
+                                                                                 IsChecked="{Binding IsCorrect, Mode=TwoWay}"
+                                                                                 Foreground="{StaticResource TeacherAccentBrush}"
+                                                                                 ToolTip="Dogru secenek" />
+                                                                    <TextBox Grid.Column="1"
+                                                                             Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                             Background="#12172A"
+                                                                             Foreground="White"
+                                                                             BorderBrush="{StaticResource TeacherAccentMutedBrush}"
+                                                                             Padding="6"
+                                                                             TextWrapping="Wrap" />
+                                                                    <Button Grid.Column="2"
+                                                                            Content="Sil"
+                                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                                            Command="{Binding DataContext.RemoveEditableOptionCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                            CommandParameter="{Binding}"
+                                                                            Margin="12,0,0,0" />
+                                                                </Grid>
+                                                            </Border>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+
+                                                <StackPanel Orientation="Horizontal"
+                                                            Margin="0,12,0,0">
+                                                    <Button Content="Secenek Ekle"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding AddEditableOptionCommand}"
+                                                            Margin="0,0,12,0" />
+                                                    <Button Content="Soruyu Kaydet"
+                                                            Style="{StaticResource AccentButtonStyle}"
+                                                            Command="{Binding SaveQuestionEditCommand}" />
+                                                </StackPanel>
+
+                                                <TextBlock Text="{Binding QuestionEditStatusMessage}"
+                                                           Margin="0,12,0,0"
+                                                           Foreground="{StaticResource TeacherAccentBrush}"
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </Border>
+
+                                        <Border Background="#1B2238"
+                                                CornerRadius="16"
+                                                Padding="16">
+                                            <StackPanel>
+                                                <TextBlock Text="Ses Ayarları"
+                                                           FontSize="18"
+                                                           FontWeight="Bold" />
+                                                <Grid Margin="0,12,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Doğru Cevap"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding CorrectSoundDisplay}"
+                                                               Margin="12,0,12,0"
+                                                               VerticalAlignment="Center"
+                                                               Opacity="0.75" />
+                                                    <Button Grid.Column="2"
+                                                            Content="Ses Seç"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding SelectCorrectSoundCommand}" />
+                                                    <Button Grid.Column="3"
+                                                            Content="Önizle"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding PreviewCorrectSoundCommand}"
+                                                            Margin="8,0,0,0" />
+                                                    <Button Grid.Column="4"
+                                                            Content="Temizle"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding ClearCorrectSoundCommand}"
+                                                            Margin="8,0,0,0" />
+                                                </Grid>
+                                                <Grid Margin="0,8,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Yanlış Cevap"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding IncorrectSoundDisplay}"
+                                                               Margin="12,0,12,0"
+                                                               VerticalAlignment="Center"
+                                                               Opacity="0.75" />
+                                                    <Button Grid.Column="2"
+                                                            Content="Ses Seç"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding SelectIncorrectSoundCommand}" />
+                                                    <Button Grid.Column="3"
+                                                            Content="Önizle"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding PreviewIncorrectSoundCommand}"
+                                                            Margin="8,0,0,0" />
+                                                    <Button Grid.Column="4"
+                                                            Content="Temizle"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding ClearIncorrectSoundCommand}"
+                                                            Margin="8,0,0,0" />
+                                                </Grid>
+                                                <Grid Margin="0,8,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Kutlama"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding CelebrationSoundDisplay}"
+                                                               Margin="12,0,12,0"
+                                                               VerticalAlignment="Center"
+                                                               Opacity="0.75" />
+                                                    <Button Grid.Column="2"
+                                                            Content="Ses Seç"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding SelectCelebrationSoundCommand}" />
+                                                    <Button Grid.Column="3"
+                                                            Content="Önizle"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding PreviewCelebrationSoundCommand}"
+                                                            Margin="8,0,0,0" />
+                                                    <Button Grid.Column="4"
+                                                            Content="Temizle"
+                                                            Style="{StaticResource SecondaryButtonStyle}"
+                                                            Command="{Binding ClearCelebrationSoundCommand}"
+                                                            Margin="8,0,0,0" />
+                                                </Grid>
+                                            </StackPanel>
+                                        </Border>
+                                    </StackPanel>
+
+                                    <Grid Grid.Row="4"
+                                          Margin="0,20,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="2*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Border Background="#1B2238"
+                                                CornerRadius="18"
+                                                Padding="20"
+                                                Margin="0,0,20,0">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding CurrentQuestionTitle}"
+                                                           FontSize="22"
+                                                           FontWeight="Bold" />
+                                                <TextBlock Text="{Binding SelectedClass.Name, StringFormat=Sinif: {0}}"
+                                                           Margin="0,6,0,0"
+                                                           Opacity="0.8" />
+                                                <Grid Margin="0,16,0,0">
+                                                    <ProgressBar Minimum="0"
+                                                                 Maximum="1"
+                                                                 Height="12"
+                                                                 Value="{Binding QuizProgressValue}">
+                                                        <ProgressBar.Resources>
+                                                            <SolidColorBrush x:Key="ProgressBarForeground"
+                                                                             Color="#FF6BEFFF" />
+                                                            <SolidColorBrush x:Key="ProgressBarBackground"
+                                                                             Color="#33162D56" />
+                                                        </ProgressBar.Resources>
+                                                    </ProgressBar>
+                                                    <TextBlock Text="{Binding QuizProgressText}"
+                                                               HorizontalAlignment="Right"
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,-2,4,0"
+                                                               FontWeight="Bold" />
+                                                </Grid>
+                                                <TextBlock Text="{Binding QuizStatus}"
+                                                           Margin="0,12,0,0"
+                                                           Opacity="0.8" />
+                                                <TextBlock Text="{Binding AnswerRevealStatus, StringFormat=Cevap Durumu: {0}}"
+                                                           Margin="0,4,0,12"
+                                                           Opacity="0.75" />
+
+                                                <TextBlock Text="Quiz baslatilmadi."
+                                                           FontStyle="Italic"
+                                                           Opacity="0.7">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding CurrentQuestion}" Value="{x:Null}">
+                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+
+                                                <ContentControl Content="{Binding CurrentQuestion}">
+                                                    <ContentControl.Style>
+                                                        <Style TargetType="ContentControl">
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding CurrentQuestion}" Value="{x:Null}">
+                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </ContentControl.Style>
+                                                    <ContentControl.ContentTemplate>
+                                                        <DataTemplate DataType="{x:Type viewModels:QuizQuestionViewModel}">
+                                                            <StackPanel>
+                                                                <TextBlock Text="{Binding Prompt}"
+                                                                           FontSize="18"
+                                                                           FontWeight="SemiBold"
+                                                                           TextWrapping="Wrap" />
+                                                                <ItemsControl ItemsSource="{Binding Options}"
+                                                                              Margin="0,18,0,0">
+                                                                    <ItemsControl.ItemTemplate>
+                                                                        <DataTemplate DataType="{x:Type viewModels:QuizOptionItemViewModel}">
+                                                                            <Border CornerRadius="14"
+                                                                                    Padding="12"
+                                                                                    Margin="0,0,0,10">
+                                                                                <Border.Style>
+                                                                                    <Style TargetType="Border">
+                                                                                        <Setter Property="Background" Value="{StaticResource OptionBrushA}" />
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger Binding="{Binding Position}" Value="1">
+                                                                                                <Setter Property="Background" Value="{StaticResource OptionBrushB}" />
+                                                                                            </DataTrigger>
+                                                                                            <DataTrigger Binding="{Binding Position}" Value="2">
+                                                                                                <Setter Property="Background" Value="{StaticResource OptionBrushC}" />
+                                                                                            </DataTrigger>
+                                                                                            <DataTrigger Binding="{Binding Position}" Value="3">
+                                                                                                <Setter Property="Background" Value="{StaticResource OptionBrushD}" />
+                                                                                            </DataTrigger>
+                                                                                            <DataTrigger Binding="{Binding Position}" Value="4">
+                                                                                                <Setter Property="Background" Value="{StaticResource OptionBrushE}" />
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </Border.Style>
+                                                                                <DockPanel LastChildFill="True">
+                                                                                    <Border Width="48"
+                                                                                            Height="48"
+                                                                                            CornerRadius="24"
+                                                                                            Margin="0,0,16,0"
+                                                                                            Background="#33FFFFFF"
+                                                                                            BorderBrush="#55FFFFFF"
+                                                                                            BorderThickness="2">
+                                                                                        <TextBlock Text="{Binding Label}"
+                                                                                                   FontSize="28"
+                                                                                                   FontWeight="Bold"
+                                                                                                   HorizontalAlignment="Center"
+                                                                                                   VerticalAlignment="Center" />
+                                                                                    </Border>
+                                                                                    <TextBlock Text="{Binding Text}"
+                                                                                               FontSize="32"
+                                                                                               FontWeight="SemiBold"
+                                                                                               TextWrapping="Wrap"
+                                                                                               VerticalAlignment="Center" />
+                                                                                </DockPanel>
+                                                                            </Border>
+                                                                        </DataTemplate>
+                                                                    </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+                                                            </StackPanel>
+                                                        </DataTemplate>
+                                                    </ContentControl.ContentTemplate>
+                                                </ContentControl>
+                                            </StackPanel>
+                                        </Border>
+
+                                        <Border Grid.Column="1"
+                                                Background="#331C3563"
+                                                CornerRadius="18"
+                                                Padding="20">
+                                            <StackPanel>
+                                                <TextBlock Text="Quiz Yol Haritasi"
+                                                           FontSize="18"
+                                                           FontWeight="SemiBold"
+                                                           Margin="0,0,0,12" />
+                                                <ListBox ItemsSource="{Binding QuizQuestions}"
+                                                         SelectedItem="{Binding CurrentQuestion}"
+                                                         IsHitTestVisible="False"
+                                                         Background="Transparent"
+                                                         BorderThickness="0">
+                                                    <ListBox.ItemTemplate>
+                                                        <DataTemplate DataType="{x:Type viewModels:QuizQuestionViewModel}">
+                                                            <Border CornerRadius="12"
+                                                                    Padding="12"
+                                                                    Margin="0,0,0,10">
+                                                                <Border.Style>
+                                                                    <Style TargetType="Border">
+                                                                        <Setter Property="Background" Value="#1B2238" />
+                                                                        <Setter Property="Opacity" Value="0.8" />
+                                                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                                                        <Setter Property="BorderThickness" Value="1" />
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
+                                                                                <Setter Property="Background" Value="{StaticResource TeacherAccentBrush}" />
+                                                                                <Setter Property="Opacity" Value="1" />
+                                                                                <Setter Property="BorderBrush" Value="{StaticResource TeacherAccentBrush}" />
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </Border.Style>
+                                                                <StackPanel>
+                                                                    <TextBlock Text="{Binding DisplayPrompt}"
+                                                                               FontWeight="SemiBold"
+                                                                               TextWrapping="Wrap" />
+                                                                    <TextBlock Text="{Binding Options.Count, StringFormat=Secenek sayisi: {0}}"
+                                                                               Opacity="0.7"
+                                                                               Margin="0,4,0,0" />
+                                                                </StackPanel>
+                                                            </Border>
+                                                        </DataTemplate>
+                                                    </ListBox.ItemTemplate>
+                                                </ListBox>
+                                            </StackPanel>
+                                        </Border>
+                                    </Grid>
+                                </Grid>
+
+                                <Grid x:Name="QuizQuestionBankContent"
+                                      Visibility="{Binding IsQuizQuestionBankSubMenuActive, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <StackPanel Grid.Row="0"
+                                                Margin="0,0,0,12">
+                                        <TextBlock Text="Soru Bankası"
                                                    FontSize="22"
                                                    FontWeight="Bold" />
-                                        <TextBlock Text="{Binding SelectedClass.Name, StringFormat=Sinif: {0}}"
-                                                   Margin="0,6,0,0"
-                                                   Opacity="0.8" />
-                                        <Grid Margin="0,16,0,0">
-                                            <ProgressBar Minimum="0"
-                                                         Maximum="1"
-                                                         Height="12"
-                                                         Value="{Binding QuizProgressValue}">
-                                                <ProgressBar.Resources>
-                                                    <SolidColorBrush x:Key="ProgressBarForeground"
-                                                                     Color="#FF6BEFFF" />
-                                                    <SolidColorBrush x:Key="ProgressBarBackground"
-                                                                     Color="#33162D56" />
-                                                </ProgressBar.Resources>
-                                            </ProgressBar>
-                                            <TextBlock Text="{Binding QuizProgressText}"
-                                                       HorizontalAlignment="Right"
-                                                       VerticalAlignment="Center"
-                                                       Margin="0,-2,4,0"
-                                                       FontWeight="Bold" />
-                                        </Grid>
-                                        <TextBlock Text="{Binding QuizStatus}"
-                                                   Margin="0,12,0,0"
-                                                   Opacity="0.8" />
-                                        <TextBlock Text="{Binding AnswerRevealStatus, StringFormat=Cevap Durumu: {0}}"
-                                                   Margin="0,4,0,12"
+                                        <TextBlock Text="{Binding QuestionBank.Count, StringFormat=Listelenen soru: {0}}"
+                                                   Margin="0,4,0,0"
                                                    Opacity="0.75" />
-
-                                        <TextBlock Text="Quiz baslatilmadi."
-                                                   FontStyle="Italic"
-                                                   Opacity="0.7">
-                                            <TextBlock.Style>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="Visibility" Value="Collapsed" />
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CurrentQuestion}" Value="{x:Null}">
-                                                            <Setter Property="Visibility" Value="Visible" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </TextBlock.Style>
-                                        </TextBlock>
-
-                                        <ContentControl Content="{Binding CurrentQuestion}">
-                                            <ContentControl.Style>
-                                                <Style TargetType="ContentControl">
-                                                    <Setter Property="Visibility" Value="Visible" />
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CurrentQuestion}" Value="{x:Null}">
-                                                            <Setter Property="Visibility" Value="Collapsed" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </ContentControl.Style>
-                                            <ContentControl.ContentTemplate>
-                                                <DataTemplate DataType="{x:Type viewModels:QuizQuestionViewModel}">
-                                                    <StackPanel>
-                                                        <TextBlock Text="{Binding Prompt}"
-                                                                   FontSize="18"
-                                                                   FontWeight="SemiBold"
-                                                                   TextWrapping="Wrap" />
-                                                        <ItemsControl ItemsSource="{Binding Options}"
-                                                                      Margin="0,18,0,0">
-                                                            <ItemsControl.ItemTemplate>
-                                                                <DataTemplate DataType="{x:Type viewModels:QuizOptionItemViewModel}">
-                                                                    <Border CornerRadius="14"
-                                                                            Padding="12"
-                                                                            Margin="0,0,0,10">
-                                                                        <Border.Style>
-                                                                            <Style TargetType="Border">
-                                                                                <Setter Property="Background" Value="{StaticResource OptionBrushA}" />
-                                                                                <Style.Triggers>
-                                                                                    <DataTrigger Binding="{Binding Position}" Value="1">
-                                                                                        <Setter Property="Background" Value="{StaticResource OptionBrushB}" />
-                                                                                    </DataTrigger>
-                                                                                    <DataTrigger Binding="{Binding Position}" Value="2">
-                                                                                        <Setter Property="Background" Value="{StaticResource OptionBrushC}" />
-                                                                                    </DataTrigger>
-                                                                                    <DataTrigger Binding="{Binding Position}" Value="3">
-                                                                                        <Setter Property="Background" Value="{StaticResource OptionBrushD}" />
-                                                                                    </DataTrigger>
-                                                                                    <DataTrigger Binding="{Binding Position}" Value="4">
-                                                                                        <Setter Property="Background" Value="{StaticResource OptionBrushE}" />
-                                                                                    </DataTrigger>
-                                                                                </Style.Triggers>
-                                                                            </Style>
-                                                                        </Border.Style>
-                                                                        <DockPanel LastChildFill="True">
-                                                                            <TextBlock Text="{Binding Text}"
-                                                                                       FontWeight="SemiBold"
-                                                                                       TextWrapping="Wrap" />
-                                                                            <TextBlock Text="✔"
-                                                                                       FontWeight="Bold"
-                                                                                       Margin="8,0,0,0"
-                                                                                       Visibility="{Binding DataContext.IsAnswerRevealEnabled, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                                                       DockPanel.Dock="Right" />
-                                                                        </DockPanel>
-                                                                    </Border>
-                                                                </DataTemplate>
-                                                            </ItemsControl.ItemTemplate>
-                                                        </ItemsControl>
-                                                    </StackPanel>
-                                                </DataTemplate>
-                                            </ContentControl.ContentTemplate>
-                                        </ContentControl>
                                     </StackPanel>
-                                </Border>
 
-                                <Border Grid.Column="1"
-                                        Background="#331C3563"
-                                        CornerRadius="18"
-                                        Padding="20">
-                                    <StackPanel>
-                                        <TextBlock Text="Quiz Yol Haritasi"
-                                                   FontSize="18"
-                                                   FontWeight="SemiBold"
-                                                   Margin="0,0,0,12" />
-                                        <ListBox ItemsSource="{Binding QuizQuestions}"
-                                                 SelectedItem="{Binding CurrentQuestion}"
-                                                 IsHitTestVisible="False"
-                                                 Background="Transparent"
-                                                 BorderThickness="0">
-                                            <ListBox.ItemTemplate>
-                                                <DataTemplate DataType="{x:Type viewModels:QuizQuestionViewModel}">
-                                                    <Border CornerRadius="12"
-                                                            Padding="12"
-                                                            Margin="0,0,0,10">
-                                                        <Border.Style>
-                                                            <Style TargetType="Border">
-                                                                <Setter Property="Background" Value="#1B2238" />
-                                                                <Setter Property="Opacity" Value="0.8" />
-                                                                <Setter Property="BorderBrush" Value="Transparent" />
-                                                                <Setter Property="BorderThickness" Value="1" />
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected}" Value="True">
-                                                                        <Setter Property="Background" Value="#4433A2FF" />
-                                                                        <Setter Property="Opacity" Value="1" />
-                                                                        <Setter Property="BorderBrush" Value="{StaticResource TeacherAccentBrush}" />
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </Border.Style>
-                                                        <StackPanel>
-                                                            <TextBlock Text="{Binding DisplayPrompt}"
-                                                                       FontWeight="SemiBold"
-                                                                       TextWrapping="Wrap" />
-                                                            <TextBlock Text="{Binding Options.Count, StringFormat=Secenek sayisi: {0}}"
-                                                                       Opacity="0.7"
-                                                                       Margin="0,4,0,0" />
-                                                        </StackPanel>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ListBox.ItemTemplate>
-                                        </ListBox>
+                                    <WrapPanel Grid.Row="1"
+                                               Margin="0,0,0,12">
+                                        <StackPanel Width="220"
+                                                    Margin="0,0,16,12">
+                                            <TextBlock Text="Sinif Secimi"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Opacity="0.85" />
+                                            <ComboBox ItemsSource="{Binding Classes}"
+                                                      SelectedItem="{Binding SelectedClass, Mode=TwoWay}"
+                                                      DisplayMemberPath="Name"
+                                                      Padding="8,4"
+                                                      Background="#1B2238"
+                                                      Foreground="White" />
+                                        </StackPanel>
+                                        <StackPanel Width="220"
+                                                    Margin="0,0,16,12">
+                                            <TextBlock Text="Unite"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Opacity="0.85" />
+                                            <ComboBox ItemsSource="{Binding SelectedClass.Units}"
+                                                      SelectedItem="{Binding SelectedUnit, Mode=TwoWay}"
+                                                      DisplayMemberPath="Name"
+                                                      Padding="8,4"
+                                                      Background="#1B2238"
+                                                      Foreground="White" />
+                                        </StackPanel>
+                                        <StackPanel Margin="0,0,16,12">
+                                            <TextBlock Text="Özet"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Opacity="0.85" />
+                                            <TextBlock Text="{Binding SelectedUnit.QuestionCount, StringFormat=Ünite sorusu: {0}}"
+                                                       Margin="0,6,0,0"
+                                                       Opacity="0.8" />
+                                        </StackPanel>
+                                    </WrapPanel>
+
+                                    <StackPanel Grid.Row="2"
+                                                Margin="0,0,0,12">
+                                        <StackPanel Orientation="Horizontal"
+                                                    Margin="0,0,0,8">
+                                            <Button Content="Soru Bankasını Yükle"
+                                                    Style="{StaticResource SecondaryButtonStyle}"
+                                                    Command="{Binding LoadQuestionBankCommand}"
+                                                    Margin="0,0,12,0" />
+                                            <Button Content="PDF'den Soru Aktar"
+                                                    Style="{StaticResource SecondaryButtonStyle}"
+                                                    Command="{Binding ImportQuestionsCommand}" />
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal"
+                                                    Margin="0,0,0,8"
+                                                    Visibility="{Binding IsQuestionBankLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <ProgressBar Width="160"
+                                                         Height="10"
+                                                         IsIndeterminate="True"
+                                                         Margin="0,0,8,0" />
+                                            <TextBlock Text="Soru bankasi yukleniyor..."
+                                                       VerticalAlignment="Center" />
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding QuestionBankStatus}"
+                                                   Opacity="0.8" />
                                     </StackPanel>
-                                </Border>
+
+                                    <Border Grid.Row="3"
+                                            Background="#22182C4A"
+                                            CornerRadius="16"
+                                            Padding="16"
+                                            MaxHeight="360">
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{Binding QuestionBank}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <WrapPanel />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type viewModels:QuestionBankItemViewModel}">
+                                                        <Border Width="260"
+                                                                Margin="0,0,12,12"
+                                                                Padding="12"
+                                                                CornerRadius="12"
+                                                                Background="#1B2238"
+                                                                BorderBrush="#33FFFFFF"
+                                                                BorderThickness="1">
+                                                            <StackPanel>
+                                                                <TextBlock Text="{Binding DisplayOrder}"
+                                                                           FontWeight="Bold"
+                                                                           FontSize="12"
+                                                                           Opacity="0.7" />
+                                                                <TextBlock Text="{Binding Prompt}"
+                                                                           FontWeight="SemiBold"
+                                                                           Margin="0,6,0,0"
+                                                                           TextWrapping="Wrap" />
+                                                                <TextBlock Text="{Binding CorrectAnswer, StringFormat=Doğru: {0}}"
+                                                                           Margin="0,8,0,0"
+                                                                           Opacity="0.85"
+                                                                           TextWrapping="Wrap" />
+                                                                <TextBlock Text="{Binding OptionCount, StringFormat=Şık sayısı: {0}}"
+                                                                           Margin="0,4,0,0"
+                                                                           Opacity="0.65" />
+                                                            </StackPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </Border>
+
+                                    <Border Grid.Row="4"
+                                            Background="#1B2238"
+                                            CornerRadius="16"
+                                            Padding="16"
+                                            Margin="0,16,0,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Toplu Soru Ekleme"
+                                                       FontSize="18"
+                                                       FontWeight="Bold" />
+                                            <TextBlock Text="Her soruyu bos satirla ayirin. Dogru secenegi '*' ile isaretleyin (ornegin *Dogru cevap)."
+                                                       Margin="0,8,0,12"
+                                                       TextWrapping="Wrap"
+                                                       Opacity="0.75" />
+                                            <TextBox Text="{Binding BulkQuestionInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     AcceptsReturn="True"
+                                                     TextWrapping="Wrap"
+                                                     VerticalScrollBarVisibility="Auto"
+                                                     MinHeight="140"
+                                                     Background="#12172A"
+                                                     Foreground="White"
+                                                     BorderBrush="{StaticResource TeacherAccentMutedBrush}"
+                                                     Padding="8" />
+                                            <StackPanel Orientation="Horizontal"
+                                                        Margin="0,12,0,0">
+                                                <Button Content="Toplu Sorulari Ekle"
+                                                        Style="{StaticResource AccentButtonStyle}"
+                                                        Command="{Binding AddBulkQuestionsCommand}" />
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding BulkQuestionStatusMessage}"
+                                                       Margin="0,12,0,0"
+                                                       Foreground="{StaticResource TeacherAccentBrush}"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
                             </Grid>
                         </Grid>
-                        <Grid x:Name="QuestionBankContent"
-                              Visibility="{Binding IsQuestionBankMenuActive, Converter={StaticResource BooleanToVisibilityConverter}}">
-                            <StackPanel>
-                                <TextBlock Text="Soru Bankasi"
-                                           FontSize="24"
-                                           FontWeight="Bold"
-                                           Margin="0,0,0,16" />
-
-                                <WrapPanel Margin="0,0,0,12">
-                                    <StackPanel Width="220"
-                                                Margin="0,0,16,12">
-                                        <TextBlock Text="Sinif Secimi"
-                                                   FontSize="13"
-                                                   FontWeight="SemiBold"
-                                                   Opacity="0.85" />
-                                        <ComboBox ItemsSource="{Binding Classes}"
-                                                  SelectedItem="{Binding SelectedClass, Mode=TwoWay}"
-                                                  DisplayMemberPath="Name"
-                                                  Padding="8,4"
-                                                  Background="#1B2238"
-                                                  Foreground="White" />
-                                    </StackPanel>
-                                    <StackPanel Width="220"
-                                                Margin="0,0,16,12">
-                                        <TextBlock Text="Unite"
-                                                   FontSize="13"
-                                                   FontWeight="SemiBold"
-                                                   Opacity="0.85" />
-                                        <ComboBox ItemsSource="{Binding SelectedClass.Units}"
-                                                  SelectedItem="{Binding SelectedUnit, Mode=TwoWay}"
-                                                  DisplayMemberPath="Name"
-                                                  Padding="8,4"
-                                                  Background="#1B2238"
-                                                  Foreground="White" />
-                                    </StackPanel>
-                                </WrapPanel>
-
-                                <StackPanel Orientation="Horizontal"
-                                            Margin="0,0,0,12">
-                                    <Button Content="Soru Bankasini Yukle"
-                                            Style="{StaticResource SecondaryButtonStyle}"
-                                            Command="{Binding LoadQuestionBankCommand}"
-                                            Margin="0,0,12,0" />
-                                    <Button Content="PDF'den Soru Aktar"
-                                            Style="{StaticResource SecondaryButtonStyle}"
-                                            Command="{Binding ImportQuestionsCommand}" />
-                                </StackPanel>
-
-                                <StackPanel Orientation="Horizontal"
-                                            Margin="0,0,0,8"
-                                            Visibility="{Binding IsQuestionBankLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                    <ProgressBar Width="160"
-                                                 Height="10"
-                                                 IsIndeterminate="True"
-                                                 Margin="0,0,8,0" />
-                                    <TextBlock Text="Soru bankasi yukleniyor..."
-                                               VerticalAlignment="Center" />
-                                </StackPanel>
-
-                                <TextBlock Text="{Binding QuestionBankStatus}"
-                                           Opacity="0.8"
-                                           Margin="0,0,0,12" />
-
-                                <Border Background="#22182C4A"
-                                        CornerRadius="16"
-                                        Padding="16"
-                                        MaxHeight="360">
-                                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                                        <ItemsControl ItemsSource="{Binding QuestionBank}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate DataType="{x:Type viewModels:QuestionBankItemViewModel}">
-                                                    <StackPanel Margin="0,0,0,14">
-                                                        <TextBlock Text="{Binding Prompt}"
-                                                                   FontWeight="SemiBold"
-                                                                   TextWrapping="Wrap" />
-                                                        <ItemsControl ItemsSource="{Binding Options}"
-                                                                      Margin="12,6,0,0">
-                                                            <ItemsControl.ItemTemplate>
-                                                                <DataTemplate>
-                                                                    <TextBlock Text="{Binding}"
-                                                                               FontStyle="Italic"
-                                                                               Opacity="0.7" />
-                                                                </DataTemplate>
-                                                            </ItemsControl.ItemTemplate>
-                                                        </ItemsControl>
-                                                    </StackPanel>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                    </ScrollViewer>
-                                </Border>
-                            </StackPanel>
-                        </Grid>
-
                         <Grid x:Name="PeopleContent"
                               Visibility="{Binding IsPeopleMenuActive, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <StackPanel>


### PR DESCRIPTION
## Summary
- add celebration sound support to the shared sound settings/player and surface selection controls in the teacher dashboard
- rework the quiz menu to include an in-panel question bank sub menu with simplified cards, counts, and relocated bulk add tools
- steady the projector celebration overlay while triggering the optional celebration audio cue

## Testing
- `dotnet build` *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8ca498b5883288aba1fa6baa35e1a